### PR TITLE
Use the original service ID instead of its alias

### DIFF
--- a/Command/SendEmailCommand.php
+++ b/Command/SendEmailCommand.php
@@ -49,7 +49,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $mailer     = $this->getContainer()->get('mailer');
+        $mailer     = $this->getContainer()->get('swiftmailer.mailer');
         $transport  = $mailer->getTransport();
 
         if ($transport instanceof \Swift_Transport_SpoolTransport) {


### PR DESCRIPTION
`mailer` is just an alias and an app-specific service can use this name instead. To avoid collisions, use the original `swiftmailer.mailer` service ID.
