### PR TITLE
Made the `swiftmailer.mailer` service public and made the command use it instead of the `mailer` alias.

### DIFF
--- a/Command/SendEmailCommand.php
+++ b/Command/SendEmailCommand.php
@@ -49,7 +49,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $mailer     = $this->getContainer()->get('mailer');
+        $mailer     = $this->getContainer()->get('swiftmailer.mailer');
         $transport  = $mailer->getTransport();
 
         if ($transport instanceof \Swift_Transport_SpoolTransport) {

--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -23,7 +23,7 @@
     </parameters>
 
     <services>
-        <service id="swiftmailer.mailer" class="%swiftmailer.class%" public="false">
+        <service id="swiftmailer.mailer" class="%swiftmailer.class%"">
             <argument type="service" id="swiftmailer.transport" />
         </service>
 


### PR DESCRIPTION
This is a fixed version of the #25 PR. I've made the service public so that there is no need to use the alias.
