### PR TITLE
Added classes to cache

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -127,6 +127,10 @@ class SwiftmailerExtension extends Extension
             $container->setParameter('swiftmailer.single_address', null);
         }
         $container->setParameter('swiftmailer.delivery_whitelist', $config['delivery_whitelist']);
+
+        $this->addClassesToCompile(array(
+            'Symfony\\Bundle\\SwiftmailerBundle\\EventListener\\EmailSenderListener',
+        ));
     }
 
     /**


### PR DESCRIPTION
Hello,

This commit adds some used classes to Symfony2 cache.
 See the talk in sensio/SensioDistributionBundle#76

Let me know if it needs anything else/if I've did it against the wrong branch (it should go into 2.2 distro).

Thanks.
