### PR TITLE
messagePart.charset is not defined for Swift_Attachments

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -47,7 +47,7 @@
 
             <p>
                 <pre>
-                    {%- if message.charset %}
+                    {%- if messagePart.charset is defined and message.charset %}
                         {{- message.body|e('html', message.charset)|convert_encoding('UTF-8', message.charset) }}
                     {%- else %}
                         {{- message.body|e('html') }}


### PR DESCRIPTION
Fix for this error:

`Method "charset" for object "Swift_Attachment" does not exist in SwiftmailerBundle:Collector:swiftmailer.html.twig at line 61`
