### PR TITLE
support LoadBalancedTransport in SendEmailCommand

### DIFF
--- a/Command/SendEmailCommand.php
+++ b/Command/SendEmailCommand.php
@@ -13,14 +13,15 @@ namespace Symfony\Bundle\SwiftmailerBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Send Emails from the spool.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Clément JOBEILI <clement.jobeili@gmail.com>
+ * @author Toni Uebernickel <tuebernickel@gmail.com>
  */
 class SendEmailCommand extends ContainerAwareCommand
 {
@@ -32,10 +33,11 @@ class SendEmailCommand extends ContainerAwareCommand
         $this
             ->setName('swiftmailer:spool:send')
             ->setDescription('Sends emails from the spool')
-            ->addOption('message-limit', 0, InputOption::VALUE_OPTIONAL, 'The maximum number of messages to send.')
-            ->addOption('time-limit', 0, InputOption::VALUE_OPTIONAL, 'The time limit for sending messages (in seconds).')
-            ->addOption('recover-timeout', 0, InputOption::VALUE_OPTIONAL, 'The timeout for recovering messages that have taken too long to send (in seconds).')
-            ->addOption('mailer', null, InputOption::VALUE_OPTIONAL, 'The mailer name.')
+            ->addOption('message-limit', null, InputOption::VALUE_REQUIRED, 'The maximum number of messages to send.')
+            ->addOption('time-limit', null, InputOption::VALUE_REQUIRED, 'The time limit for sending messages (in seconds).')
+            ->addOption('recover-timeout', null, InputOption::VALUE_REQUIRED, 'The timeout for recovering messages that have taken too long to send (in seconds).')
+            ->addOption('mailer', null, InputOption::VALUE_REQUIRED, 'The mailer name.')
+            ->addOption('transport', null, InputOption::VALUE_REQUIRED, 'The service of the transport to use to send the messages.')
             ->setHelp(<<<EOF
 The <info>swiftmailer:spool:send</info> command sends all emails from the spool.
 
@@ -62,7 +64,7 @@ EOF
         }
     }
 
-    private function processMailer($name, $input, $output)
+    private function processMailer($name, InputInterface $input, OutputInterface $output)
     {
         if (!$this->getContainer()->has(sprintf('swiftmailer.mailer.%s', $name))) {
             throw new \InvalidArgumentException(sprintf('The mailer "%s" does not exist.', $name));
@@ -72,25 +74,40 @@ EOF
         if ($this->getContainer()->getParameter(sprintf('swiftmailer.mailer.%s.spool.enabled', $name))) {
             $mailer = $this->getContainer()->get(sprintf('swiftmailer.mailer.%s', $name));
             $transport = $mailer->getTransport();
-            if ($transport instanceof \Swift_Transport_SpoolTransport) {
-                $spool = $transport->getSpool();
-                if ($spool instanceof \Swift_ConfigurableSpool) {
-                    $spool->setMessageLimit($input->getOption('message-limit'));
-                    $spool->setTimeLimit($input->getOption('time-limit'));
-                }
-                if ($spool instanceof \Swift_FileSpool) {
-                    if (null !== $input->getOption('recover-timeout')) {
-                        $spool->recover($input->getOption('recover-timeout'));
-                    } else {
-                        $spool->recover();
-                    }
-                }
-                $sent = $spool->flushQueue($this->getContainer()->get(sprintf('swiftmailer.mailer.%s.transport.real', $name)));
 
-                $output->writeln(sprintf('<comment>%d</comment> emails sent', $sent));
+            if ($transport instanceof \Swift_Transport_LoadBalancedTransport) {
+                foreach ($transport->getTransports() as $eachTransport) {
+                    $this->recoverSpool($name, $eachTransport, $input, $output);
+                }
             }
+
+            $this->recoverSpool($name, $transport, $input, $output);
         } else {
             $output->writeln('No email to send as the spool is disabled.');
+        }
+    }
+
+    private function recoverSpool($name, \Swift_Transport $transport, InputInterface $input, OutputInterface $output)
+    {
+        if ($transport instanceof \Swift_Transport_SpoolTransport) {
+            $spool = $transport->getSpool();
+            if ($spool instanceof \Swift_ConfigurableSpool) {
+                $spool->setMessageLimit($input->getOption('message-limit'));
+                $spool->setTimeLimit($input->getOption('time-limit'));
+            }
+
+            if ($spool instanceof \Swift_FileSpool) {
+                if (null !== $input->getOption('recover-timeout')) {
+                    $spool->recover($input->getOption('recover-timeout'));
+                } else {
+                    $spool->recover();
+                }
+            }
+
+            $transportService = $input->getOption('transport') ?: sprintf('swiftmailer.mailer.%s.transport.real', $name);
+            $sent = $spool->flushQueue($this->getContainer()->get($transportService));
+
+            $output->writeln(sprintf('<comment>%d</comment> emails sent', $sent));
         }
     }
 }

--- a/Tests/Command/SendEmailCommandTest.php
+++ b/Tests/Command/SendEmailCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Symfony\Bundle\SwiftmailerBundle\Tests\Command;
+
+use Symfony\Bundle\SwiftmailerBundle\Command\SendEmailCommand;
+use Symfony\Bundle\SwiftmailerBundle\Tests\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @covers Symfony\Bundle\SwiftmailerBundle\Command\SendEmailCommand
+ */
+class SendEmailCommandTest extends TestCase
+{
+    public function testRecoverSpoolTransport()
+    {
+        $realTransport = $this->getMock('Swift_Transport');
+
+        $spool = $this->getMock('Swift_Spool');
+        $spool
+            ->expects($this->once())
+            ->method('flushQueue')
+            ->with($realTransport)
+            ->will($this->returnValue(5))
+        ;
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $container = $this->buildContainer($spoolTransport, $realTransport);
+        $tester = $this->executeCommand($container);
+
+        $this->assertStringEndsWith("5 emails sent\n", $tester->getDisplay());
+    }
+
+    public function testRecoverLoadbalancedTransportWithSpool()
+    {
+        $realTransport = $this->getMock('Swift_Transport');
+
+        $spool = $this->getMock('Swift_Spool');
+        $spool
+            ->expects($this->once())
+            ->method('flushQueue')
+            ->with($realTransport)
+            ->will($this->returnValue(7))
+        ;
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $loadBalancedTransport = new \Swift_Transport_LoadBalancedTransport();
+        $loadBalancedTransport->setTransports(array($spoolTransport));
+
+        $container = $this->buildContainer($loadBalancedTransport, $realTransport);
+        $tester = $this->executeCommand($container);
+
+        $this->assertStringEndsWith("7 emails sent\n", $tester->getDisplay());
+    }
+
+    /**
+     * Builds a container with a named mailer.
+     *
+     * @param \Swift_Transport $transport
+     * @param \Swift_Transport $realTransport
+     * @param string           $name
+     *
+     * @return Container
+     */
+    private function buildContainer($transport, $realTransport, $name = 'default')
+    {
+        $mailer = new \Swift_Mailer($transport);
+
+        $container = new Container();
+        $container->set(sprintf('swiftmailer.mailer.%s', $name), $mailer);
+        $container->set(sprintf('swiftmailer.mailer.%s.transport.real', $name), $realTransport);
+        $container->setParameter('swiftmailer.mailers', array($name => $mailer));
+        $container->setParameter(sprintf('swiftmailer.mailer.%s.spool.enabled', $name), true);
+
+        return $container;
+    }
+
+    /**
+     * Executes the command with the given container.
+     *
+     * @param ContainerInterface $container
+     * @param array              $input
+     * @param array              $options
+     *
+     * @return CommandTester
+     */
+    private function executeCommand(ContainerInterface $container, $input = array(), $options = array())
+    {
+        $command = new SendEmailCommand();
+        $command->setContainer($container);
+
+        $tester = new CommandTester($command);
+        $tester->execute($input, $options);
+
+        return $tester;
+    }
+}

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -13,10 +13,10 @@ namespace Symfony\Bundle\SwiftmailerBundle\Tests;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
+    public static function setUpBeforeClass()
     {
         if (!class_exists('Swift_Mailer')) {
-            $this->markTestSkipped('Swiftmailer is not available.');
+            self::markTestSkipped('Swiftmailer is not available.');
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
         "symfony/yaml": "~2.3|~3.0"
     },
     "require-dev": {
+        "symfony/console": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {


### PR DESCRIPTION
This adds support for spooled transports utilized within a failover (or load-balanced) transport.

In addition it adds support for user defined service names.