### PR TITLE
fix checking of mailer services in EmailSenderListener

### DIFF
--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -40,7 +40,7 @@ class EmailSenderListener implements EventSubscriberInterface
         }
         $mailers = array_keys($this->container->getParameter('swiftmailer.mailers'));
         foreach ($mailers as $name) {
-            if ($this->container instanceof IntrospectableContainerInterface ? $this->container->initialized(sprintf('swiftmailer.mailer.%s', $name)) : $this->container->has(sprintf('swiftmailer.mailer.%s', $name))) {
+            if ($this->container instanceof IntrospectableContainerInterface ? $this->container->initialized(sprintf('swiftmailer.mailer.%s', $name)) : true) {
                 if ($this->container->getParameter(sprintf('swiftmailer.mailer.%s.spool.enabled', $name))) {
                     $mailer = $this->container->get(sprintf('swiftmailer.mailer.%s', $name));
                     $transport = $mailer->getTransport();


### PR DESCRIPTION
The 'initialized' method of the Symfony\Component\DependencyInjection\Container does not handle aliases (as it is in the ContainerBuilder), but therefore the EmailSenderListener never sends emails.

This fix is related to issue #43.
