### PR TITLE
Adapt collector template name to webprofiler conventions

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -59,7 +59,7 @@ class SwiftmailerExtension extends Extension
         $container->setParameter('swiftmailer.mailers', $mailers);
         $container->setParameter('swiftmailer.default_mailer', $config['default_mailer']);
 
-        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => 'SwiftmailerBundle:Collector:swiftmailer', 'id' => 'swiftmailer'));
+        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => '@Swiftmailer/Collector/swiftmailer.html.twig', 'id' => 'swiftmailer'));
 
         $container->setAlias('mailer', 'swiftmailer.mailer');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fabpot/Twig#1156 |
| License | MIT |

Debugging the issue I noticed that the @WebProfiler templates use a different convention.

This is a quick fix.

To allow the conventions most bundles use the Twig_Loader_Filesystem needs to be updated instead.
