### PR TITLE
fixes issue #51

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -149,7 +149,6 @@ class SwiftmailerExtension extends Extension
             $container
                 ->setDefinition(sprintf('swiftmailer.mailer.%s.transport.%s', $name, $transport), $definitionDecorator)
                 ->setArguments(array(
-                    new Reference('swiftmailer.transport.mailinvoker'),
                     new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name)),
                 ))
             ;


### PR DESCRIPTION
When using the 'mail' transport, you get an exception:

Argument 2 passed to Swift_Transport_SendmailTransport::__construct() must implement interface Swift_Events_EventDispatcher

This happens because the argument to the Transport service is inserted twice. Once in the Resources/config/swiftmailer.xml, and once in the PHP code in DependencyInjection/SwiftmailerExtension.php
