### PR TITLE
Adding a default mailer name in MessageDataCollector::getMessages() to maintain BC

### DIFF
--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -113,11 +113,11 @@ class MessageDataCollector extends DataCollector
     }
 
     /**
-     * Returns the message of a mailer.
+     * Returns the messages of a mailer.
      *
      * @return array The messages.
      */
-    public function getMessages($name)
+    public function getMessages($name = 'default')
     {
         if ($data = $this->getMailerData($name)) {
             return $data['messages'];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

A change was introduced in 69d6c368fc743668a2900a3ea859763719275b82 which allowed the configuration of multiple mailers.

The `MessageDataCollector::getMessages()` method now requires a `$name` parameter to fetch messages for a specific mailer, but breaks backwards compatibility by not having a default value of "default".
