### PR TITLE
Flush spool queue for console terminate as well

### DIFF
--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\SwiftmailerBundle\EventListener;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\IntrospectableContainerInterface;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -34,7 +33,7 @@ class EmailSenderListener implements EventSubscriberInterface
         $this->container = $container;
     }
 
-    public function onTerminate($event)
+    public function onTerminate()
     {
         if (!$this->container->has('mailer')) {
             return;


### PR DESCRIPTION
Mail spool were only flush at the end of a HTTP Request (KernelEvents:TERMINATE). In case of a console command sending mail using a spool, the spool was not flushed, so no mail was sent (and in case of MemorySpool, the mail were lost).

So this PR subscribes to the ConsoleEvents:TERMINATE to do the same flushing as in the context of a HTTP request.
