### PR TITLE
ConsoleEvents is only supported in Symfony 2.3

### DIFF
--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\SwiftmailerBundle\EventListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\IntrospectableContainerInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -58,8 +57,7 @@ class EmailSenderListener implements EventSubscriberInterface
     static public function getSubscribedEvents()
     {
         return array(
-            KernelEvents::TERMINATE  => 'onTerminate',
-            ConsoleEvents::TERMINATE => 'onTerminate'
+            KernelEvents::TERMINATE  => 'onTerminate'
         );
     }
 }

--- a/Tests/EventListener/EmailSenderListenerTest.php
+++ b/Tests/EventListener/EmailSenderListenerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SwiftmailerBundle\Tests;
+
+use Symfony\Bundle\SwiftmailerBundle\Tests\TestCase;
+use Symfony\Bundle\SwiftmailerBundle\EventListener\EmailSenderListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class EmailSenderListenerTest extends TestCase
+{
+    public function testIfCorrectEventsAreAttached()
+    {
+        $actual = EmailSenderListener::getSubscribedEvents();
+        $expected = array(
+            KernelEvents::TERMINATE  => 'onTerminate'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Since the minimal requirement for this bundle is Symfony 2.1 (as far as I can see) I think Console Events should not yet be supported. Or update the minimal requirements in the composer.json?

Anyway, thanks for looking at it!
