### PR TITLE
don't share the auth handler for all smtp transport

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -124,11 +124,15 @@ class SwiftmailerExtension extends Extension
                 ->addMethodCall('setPassword', array('%swiftmailer.mailer.' . $name . '.transport.smtp.password%'))
                 ->addMethodCall('setAuthMode', array('%swiftmailer.mailer.' . $name . '.transport.smtp.auth_mode%'));
 
+            $bufferDecorator = new DefinitionDecorator('swiftmailer.transport.buffer.abstract');
+            $container
+                ->setDefinition(sprintf('swiftmailer.mailer.%s.transport.buffer', $name), $bufferDecorator);
+
             $definitionDecorator = new DefinitionDecorator('swiftmailer.transport.smtp.abstract');
             $container
                 ->setDefinition(sprintf('swiftmailer.mailer.%s.transport.smtp', $name), $definitionDecorator)
                 ->setArguments(array(
-                    new Reference('swiftmailer.transport.buffer'),
+                    new Reference(sprintf('swiftmailer.mailer.%s.transport.buffer', $name)),
                     array(new Reference(sprintf('swiftmailer.mailer.%s.transport.authhandler', $name))),
                     new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name)),
                 ))

--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -49,7 +49,7 @@
 
         <service id="swiftmailer.transport.mailinvoker" class="Swift_Transport_SimpleMailInvoker" public="false" />
 
-        <service id="swiftmailer.transport.buffer" class="Swift_Transport_StreamBuffer" public="false">
+        <service id="swiftmailer.transport.buffer.abstract" class="Swift_Transport_StreamBuffer" abstract="true" public="false">
             <argument type="service" id="swiftmailer.transport.replacementfactory" />
         </service>
 


### PR DESCRIPTION
Currently it's not possible to use different auth parameters for multiple smtp transports because the auth handler is shared. 
