### PR TITLE
fixed ServiceNotFoundException for dependency on 'swiftmailer.transport....

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -142,10 +142,17 @@ class SwiftmailerExtension extends Extension
             ;
             $container->setAlias(sprintf('swiftmailer.mailer.%s.transport', $name), sprintf('swiftmailer.mailer.%s.transport.%s', $name, $transport));
         } elseif ('sendmail' === $transport) {
+            $bufferDecorator = new DefinitionDecorator('swiftmailer.transport.buffer.abstract');
+            $container
+                ->setDefinition(sprintf('swiftmailer.mailer.%s.transport.buffer', $name), $bufferDecorator);
+
             $definitionDecorator = new DefinitionDecorator(sprintf('swiftmailer.transport.%s.abstract', $transport));
             $container
                 ->setDefinition(sprintf('swiftmailer.mailer.%s.transport.%s', $name, $transport), $definitionDecorator)
-                ->addArgument(new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name)))
+                ->setArguments(array(
+                    new Reference(sprintf('swiftmailer.mailer.%s.transport.buffer', $name)),
+                    new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name))
+                ))
             ;
             $container->setAlias(sprintf('swiftmailer.mailer.%s.transport', $name), sprintf('swiftmailer.mailer.%s.transport.%s', $name, $transport));
         } elseif ('mail' === $transport) {

--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -34,9 +34,7 @@
             <argument type="service" id="swiftmailer.transport" />
         </service>
 
-        <service id="swiftmailer.transport.sendmail.abstract" class="%swiftmailer.transport.sendmail.class%" abstract="true" public="false">
-            <argument type="service" id="swiftmailer.transport.buffer" />
-        </service>
+        <service id="swiftmailer.transport.sendmail.abstract" class="%swiftmailer.transport.sendmail.class%" abstract="true" public="false" />
 
         <service id="swiftmailer.transport.mail.abstract" class="%swiftmailer.transport.mail.class%" abstract="true" public="false">
             <argument type="service" id="swiftmailer.transport.mailinvoker" />


### PR DESCRIPTION
This PR is the fix for exception which occur when transport is sendmail

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                                          
  The service "swiftmailer.mailer.default.transport.real" has a dependency on a non-existent service "swiftmailer.transport.buffer".
```
