### PR TITLE
allow a priority flag on plugins tag to ensure correct order

### DIFF
--- a/DependencyInjection/Compiler/RegisterPluginsPass.php
+++ b/DependencyInjection/Compiler/RegisterPluginsPass.php
@@ -44,7 +44,8 @@ class RegisterPluginsPass implements CompilerPassInterface
 
     /**
      * @param ContainerBuilder $container
-     * @param string $name The tag name
+     * @param string           $name      The tag name
+     *
      * @return array
      */
     private function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
@@ -55,6 +56,7 @@ class RegisterPluginsPass implements CompilerPassInterface
             function ($tagA, $tagB) {
                 $priorityTagA = isset($tagA[0]['priority']) ? $tagA[0]['priority'] : 0;
                 $priorityTagB = isset($tagB[0]['priority']) ? $tagB[0]['priority'] : 0;
+
                 return $priorityTagA - $priorityTagB;
             }
         );

--- a/DependencyInjection/Compiler/RegisterPluginsPass.php
+++ b/DependencyInjection/Compiler/RegisterPluginsPass.php
@@ -41,12 +41,12 @@ class RegisterPluginsPass implements CompilerPassInterface
 
     /**
      * @param ContainerBuilder $container
-     * @param string $serviceId
+     * @param string $name The tag name
      * @return array
      */
-    protected function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $serviceId)
+    protected function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
     {
-        $taggedServices = $container->findTaggedServiceIds($serviceId);
+        $taggedServices = $container->findTaggedServiceIds($name);
         uasort(
             $taggedServices,
             function ($a, $b) {

--- a/DependencyInjection/Compiler/RegisterPluginsPass.php
+++ b/DependencyInjection/Compiler/RegisterPluginsPass.php
@@ -43,16 +43,17 @@ class RegisterPluginsPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param string $name The tag name
      * @return array
+     * @internal
      */
-    protected function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
+    public function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
     {
         $taggedServices = $container->findTaggedServiceIds($name);
         uasort(
             $taggedServices,
-            function ($a, $b) {
-                $a = isset($a[0]['priority']) ? $a[0]['priority'] : 0;
-                $b = isset($b[0]['priority']) ? $b[0]['priority'] : 0;
-                return $a > $b ? -1 : 1;
+            function ($tagA, $tagB) {
+                $priorityTagA = isset($tagA[0]['priority']) ? $tagA[0]['priority'] : 0;
+                $priorityTagB = isset($tagB[0]['priority']) ? $tagB[0]['priority'] : 0;
+                return $priorityTagA - $priorityTagB;
             }
         );
         return $taggedServices;

--- a/DependencyInjection/Compiler/RegisterPluginsPass.php
+++ b/DependencyInjection/Compiler/RegisterPluginsPass.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bundle\SwiftmailerBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * RegisterPluginsPass registers Swiftmailer plugins.
@@ -30,12 +30,31 @@ class RegisterPluginsPass implements CompilerPassInterface
 
         $mailers = $container->getParameter('swiftmailer.mailers');
         foreach ($mailers as $name => $mailer) {
-            $plugins = $container->findTaggedServiceIds(sprintf('swiftmailer.%s.plugin', $name));
+            $plugins = $this->findSortedByPriorityTaggedServiceIds($container, sprintf('swiftmailer.%s.plugin', $name));
             $transport = sprintf('swiftmailer.mailer.%s.transport', $name);
             $definition = $container->findDefinition($transport);
             foreach ($plugins as $id => $args) {
                 $definition->addMethodCall('registerPlugin', array(new Reference($id)));
             }
         }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $serviceId
+     * @return array
+     */
+    protected function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $serviceId)
+    {
+        $taggedServices = $container->findTaggedServiceIds($serviceId);
+        uasort(
+            $taggedServices,
+            function ($a, $b) {
+                $a = isset($a[0]['priority']) ? $a[0]['priority'] : 0;
+                $b = isset($b[0]['priority']) ? $b[0]['priority'] : 0;
+                return $a > $b ? -1 : 1;
+            }
+        );
+        return $taggedServices;
     }
 }

--- a/DependencyInjection/Compiler/RegisterPluginsPass.php
+++ b/DependencyInjection/Compiler/RegisterPluginsPass.php
@@ -22,6 +22,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterPluginsPass implements CompilerPassInterface
 {
+    /**
+     * @param ContainerBuilder $container
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->findDefinition('swiftmailer.mailer') || !$container->getParameter('swiftmailer.mailers')) {
@@ -43,9 +46,8 @@ class RegisterPluginsPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param string $name The tag name
      * @return array
-     * @internal
      */
-    public function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
+    private function findSortedByPriorityTaggedServiceIds(ContainerBuilder $container, $name)
     {
         $taggedServices = $container->findTaggedServiceIds($name);
         uasort(
@@ -56,6 +58,7 @@ class RegisterPluginsPass implements CompilerPassInterface
                 return $priorityTagA - $priorityTagB;
             }
         );
+
         return $taggedServices;
     }
 }


### PR DESCRIPTION
I registered a Reply-To Plugin (set reply to for every message) but I couldnt see the correct message in the symfony profiler because the logger plugin was registered previously.

This little helper sorts the tagged services by priorty. No BC break - without priority flags there will be the same order.