### PR TITLE
[Symfony 3.0] Drop backward compatibility for debug command

### DIFF
--- a/Command/DebugCommand.php
+++ b/Command/DebugCommand.php
@@ -31,9 +31,6 @@ class DebugCommand extends ContainerAwareCommand
     {
         $this
             ->setName('debug:swiftmailer')
-            ->setAliases(array(
-                'swiftmailer:debug',
-            ))
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A mailer name'),
             ))


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Related to https://github.com/symfony/symfony/pull/14091
Should we merge it in master create a branch for 3.0 features/bc breaks ?
