### PR TITLE
fixed template names

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.messageCount %}
@@ -24,7 +24,7 @@
             {% endfor %}
 
         {% endset %}
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
This notation has been available since Symfony 2.2 and Twig 1.10, so this is safe.