### PR TITLE
Tweaked the collector priority

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -57,7 +57,7 @@ class SwiftmailerExtension extends Extension
         $container->setParameter('swiftmailer.mailers', $mailers);
         $container->setParameter('swiftmailer.default_mailer', $config['default_mailer']);
 
-        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => '@Swiftmailer/Collector/swiftmailer.html.twig', 'id' => 'swiftmailer'));
+        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => '@Swiftmailer/Collector/swiftmailer.html.twig', 'id' => 'swiftmailer', 'priority' => 260));
 
         $container->setAlias('mailer', 'swiftmailer.mailer');
     }

--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -57,7 +57,7 @@ class SwiftmailerExtension extends Extension
         $container->setParameter('swiftmailer.mailers', $mailers);
         $container->setParameter('swiftmailer.default_mailer', $config['default_mailer']);
 
-        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => '@Swiftmailer/Collector/swiftmailer.html.twig', 'id' => 'swiftmailer', 'priority' => 260));
+        $container->findDefinition('swiftmailer.data_collector')->addTag('data_collector', array('template' => '@Swiftmailer/Collector/swiftmailer.html.twig', 'id' => 'swiftmailer', 'priority' => 245));
 
         $container->setAlias('mailer', 'swiftmailer.mailer');
     }


### PR DESCRIPTION
In symfony/symfony#16023 we're tweaking the priorities of the toolbar/profiler panels. The 260 value is the right number for SwiftMailer ... but maybe you don't want to merge it yet because this will change a lot the position of the SwiftMailer panel in the profiler/toolbar of Symfony versions older than 2.8.