### PR TITLE
Allow to setup transports via URL

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,6 +89,7 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey('name')
                 ->prototype('array')
             ->children()
+                ->scalarNode('url')->defaultNull()->end()
                 ->scalarNode('transport')->defaultValue('smtp')->end()
                 ->scalarNode('username')->defaultNull()->end()
                 ->scalarNode('password')->defaultNull()->end()

--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -75,6 +75,37 @@ class SwiftmailerExtension extends Extension
             $transport = $mailer['transport'];
         }
 
+        if (null !== $mailer['url']) {
+            $parts = parse_url($mailer['url']);
+            if (!empty($parts['scheme'])) {
+                $transport = $parts['scheme'];
+            }
+
+            if (!empty($parts['user'])) {
+                $mailer['username'] = $parts['user'];
+            }
+            if (!empty($parts['pass'])) {
+                $mailer['password']= $parts['pass'];
+            }
+            if (!empty($parts['host'])) {
+                $mailer['host'] = $parts['host'];
+            }
+            if (!empty($parts['port'])) {
+                $mailer['port'] = $parts['port'];
+            }
+            if (!empty($parts['query'])) {
+                $query = array();
+                parse_str($parts['query'], $query);
+                if (!empty($query['encryption'])) {
+                    $mailer['encryption'] = $query['encryption'];
+                }
+                if (!empty($query['auth_mode'])) {
+                    $mailer['auth_mode'] = $query['auth_mode'];
+                }
+            }
+        }
+        unset($mailer['url']);
+
         $container->setParameter(sprintf('swiftmailer.mailer.%s.transport.name', $name), $transport);
 
         if (isset($mailer['disable_delivery']) && $mailer['disable_delivery']) {

--- a/Resources/config/schema/swiftmailer-1.0.xsd
+++ b/Resources/config/schema/swiftmailer-1.0.xsd
@@ -35,6 +35,7 @@
       <xsd:attribute name="delivery-address" type="xsd:string" />
       <xsd:attribute name="disable-delivery" type="xsd:boolean" />
       <xsd:attribute name="sender-address" type="xsd:boolean" />
+      <xsd:attribute name="url" type="xsd:string" />
   </xsd:attributeGroup>
 
   <xsd:complexType name="mailer">

--- a/Tests/DependencyInjection/Fixtures/config/php/urls.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/urls.php
@@ -1,0 +1,9 @@
+<?php
+$container->loadFromExtension('swiftmailer', array(
+    'default_mailer' => 'smtp_mailer',
+    'mailers' => array(
+        'smtp_mailer' => array(
+            'url' => 'smtp://username:password@example.com:12345?encryption=tls&auth_mode=login',
+        ),
+    ),
+));

--- a/Tests/DependencyInjection/Fixtures/config/xml/urls.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/urls.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd">
+
+    <swiftmailer:config default-mailer="smtp_mailer">
+        <swiftmailer:mailer name="smtp_mailer"
+            url="smtp://username:password@example.com:12345?encryption=tls&amp;auth_mode=login">
+        </swiftmailer:mailer>
+    </swiftmailer:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/urls.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/urls.yml
@@ -1,0 +1,5 @@
+swiftmailer:
+    default_mailer: smtp_mailer
+    mailers:
+        smtp_mailer:
+            url: smtp://username:password@example.com:12345?encryption=tls&auth_mode=login

--- a/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -135,6 +135,21 @@ class SwiftmailerExtensionTest extends TestCase
         $this->assertEquals('1000', $container->getParameter('swiftmailer.mailer.third_mailer.transport.smtp.timeout'));
         $this->assertEquals('127.0.0.1', $container->getParameter('swiftmailer.mailer.third_mailer.transport.smtp.source_ip'));
     }
+    /**
+     * @dataProvider getConfigTypes
+     */
+    public function testUrls($type)
+    {
+        $container = $this->loadContainerFromFile('urls', $type);
+
+
+        $this->assertEquals('example.com', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.host'));
+        $this->assertEquals('12345', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.port'));
+        $this->assertEquals('tls', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.encryption'));
+        $this->assertEquals('username', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.username'));
+        $this->assertEquals('password', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.password'));
+        $this->assertEquals('login', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.auth_mode'));
+    }
 
         /**
      * @dataProvider getConfigTypes


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #101 
| License       | MIT
| Doc PR        | -

For example as YML

```yml
swiftmailer:
    default_mailer: smtp_mailer
    mailers:
        smtp_mailer:
            url: smtp://username:password@example.com:12345?encryption=tls&auth_mode=login
```

This is primary useful for SMTP-transports. There is no benefit, for "sendmail"-, or "mail"-transports. The intention is, that one only needs to set up one config option/parameter to define a working transport. For example see [`parameters.yml` of `symfony/symfony-standard`](https://github.com/symfony/symfony-standard/blob/2.8/app/config/parameters.yml.dist#L13-L16)

```yml
    mailer_transport:  smtp
    mailer_host:       127.0.0.1
    mailer_user:       ~
    mailer_password:   ~
```

For different stages one usually must set at least "user" and "password" and often "host" too for every stage. With this patch it would look like

```
mailer_url: 'smtp://127.0.0.1'
```