### PR TITLE
Fixed bug with exception when mailer cannot be found

### DIFF
--- a/Command/NewEmailCommand.php
+++ b/Command/NewEmailCommand.php
@@ -58,7 +58,7 @@ EOF
     {
         $mailerServiceName = sprintf('swiftmailer.mailer.%s', $input->getOption('mailer'));
         if (!$this->getContainer()->has($mailerServiceName)) {
-            throw new \InvalidArgumentException(sprintf('The mailer "%s" does not exist', $this->getOption('mailer')));
+            throw new \InvalidArgumentException(sprintf('The mailer "%s" does not exist', $input->getOption('mailer')));
         }
         switch ($input->getOption('body-source')) {
             case 'file':


### PR DESCRIPTION
When running <code>swiftmailer:email:send</code> and the mailer cannot be found, a fatal error is triggered:

    PHP Fatal error:  Call to undefined method Symfony\Bundle\SwiftmailerBundle\Command\NewEmailCommand::getOption() in /home/vagrant/current/vendor/symfony/swiftmailer-bundle/Command/NewEmailCommand.php on line 61
