### PR TITLE
Fix #132: Allow empty transport configs

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,7 +92,7 @@ class Configuration implements ConfigurationInterface
             // BC layer for "delivery_address: null" (the case of a string goes through the XML normalization too)
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
-                    return array_key_exists('delivery_address', $v) && null === $v['delivery_address'];
+                    return is_array($v) && array_key_exists('delivery_address', $v) && null === $v['delivery_address'];
                 })
                 ->then(function ($v) {
                     @trigger_error('The swiftmailer.delivery_address configuration key is deprecated since version 2.3.10 and will be removed in 3.0. Use the swiftmailer.delivery_addresses configuration key instead (or remove the empty setting)', E_USER_DEPRECATED);

--- a/Tests/DependencyInjection/Fixtures/config/php/null_mailer.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/null_mailer.php
@@ -1,0 +1,7 @@
+<?php
+$container->loadFromExtension('swiftmailer', array(
+    'default_mailer' => 'failover',
+    'mailers' => array(
+        'failover' => null,
+    ),
+));

--- a/Tests/DependencyInjection/Fixtures/config/xml/null_mailer.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/null_mailer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd">
+
+    <swiftmailer:config default-mailer="failover">
+        <swiftmailer:mailer name="failover" />
+    </swiftmailer:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/null_mailer.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/null_mailer.yml
@@ -1,0 +1,4 @@
+swiftmailer:
+    default_mailer: failover
+    mailers:
+        failover: ~

--- a/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -44,6 +44,16 @@ class SwiftmailerExtensionTest extends TestCase
     /**
      * @dataProvider getConfigTypes
      */
+    public function testMailerNullConfig($type)
+    {
+        $container = $this->loadContainerFromFile('null_mailer', $type);
+        $this->assertEquals('swiftmailer.mailer.failover.transport', (string) $container->getAlias('swiftmailer.transport'));
+    }
+
+
+    /**
+     * @dataProvider getConfigTypes
+     */
     public function testSendmailConfig($type)
     {
         $container = $this->loadContainerFromFile('sendmail', $type);
@@ -151,7 +161,7 @@ class SwiftmailerExtensionTest extends TestCase
         $this->assertEquals('login', $container->getParameter('swiftmailer.mailer.smtp_mailer.transport.smtp.auth_mode'));
     }
 
-        /**
+    /**
      * @dataProvider getConfigTypes
      */
     public function testOneMailer($type)


### PR DESCRIPTION
A fix for cases when the transport config is empty:
https://github.com/symfony/swiftmailer-bundle/issues/132#issuecomment-208896442