### PR TITLE
allow using env variables in transport configuration

### DIFF
--- a/DependencyInjection/SwiftmailerTransportFactory.php
+++ b/DependencyInjection/SwiftmailerTransportFactory.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SwiftmailerBundle\DependencyInjection;
+
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Factory to create a \Swift_Transport object.
+ *
+ * @author Romain Gautier <mail@romain.sh>
+ */
+class SwiftmailerTransportFactory
+{
+    /**
+     * @param array                         $options
+     * @param RequestContext                $requestContext
+     * @param \Swift_Events_EventDispatcher $eventDispatcher
+     *
+     * @return \Swift_Transport
+     *
+     * @throws \InvalidArgumentException if the scheme is not a built-in Swiftmailer transport
+     */
+    public static function createTransport(array $options, RequestContext $requestContext, \Swift_Events_EventDispatcher $eventDispatcher)
+    {
+        $options = static::resolveOptions($options);
+
+        if ('smtp' === $options['transport']) {
+            $smtpAuthHandler = new \Swift_Transport_Esmtp_AuthHandler(array(
+                new \Swift_Transport_Esmtp_Auth_CramMd5Authenticator(),
+                new \Swift_Transport_Esmtp_Auth_LoginAuthenticator(),
+                new \Swift_Transport_Esmtp_Auth_PlainAuthenticator(),
+            ));
+            $smtpAuthHandler->setUsername($options['username']);
+            $smtpAuthHandler->setPassword($options['password']);
+            $smtpAuthHandler->setAuthMode($options['auth_mode']);
+
+            $transport = new \Swift_Transport_EsmtpTransport(
+                new \Swift_Transport_StreamBuffer(new \Swift_StreamFilters_StringReplacementFilterFactory()),
+                array($smtpAuthHandler),
+                $eventDispatcher
+            );
+            $transport->setHost($options['host']);
+            $transport->setPort($options['port']);
+            $transport->setEncryption($options['encryption']);
+            $transport->setTimeout($options['timeout']);
+            $transport->setSourceIp($options['source_ip']);
+
+            $smtpTransportConfigurator = new SmtpTransportConfigurator(null, $requestContext);
+            $smtpTransportConfigurator->configure($transport);
+        } elseif ('sendmail' === $options['transport']) {
+            $transport = new \Swift_Transport_SendmailTransport(
+                new \Swift_Transport_StreamBuffer(new \Swift_StreamFilters_StringReplacementFilterFactory()),
+                $eventDispatcher
+            );
+
+            $smtpTransportConfigurator = new SmtpTransportConfigurator(null, $requestContext);
+            $smtpTransportConfigurator->configure($transport);
+        } elseif ('null' === $options['transport']) {
+            $transport = new \Swift_Transport_NullTransport($eventDispatcher);
+        } else {
+            throw new \InvalidArgumentException(sprintf('Not a built-in Swiftmailer transport: %s.', $options['transport']));
+        }
+
+        return $transport;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array options
+     */
+    public static function resolveOptions(array $options)
+    {
+        $options += array(
+            'transport' => null,
+            'username' => null,
+            'password' => null,
+            'host' => null,
+            'port' => null,
+            'timeout' => null,
+            'source_ip' => null,
+            'local_domain' => null,
+            'encryption' => null,
+            'auth_mode' => null,
+        );
+
+        if (isset($options['url'])) {
+            $parts = parse_url($options['url']);
+            if (isset($parts['scheme'])) {
+                $options['transport'] = $parts['scheme'];
+            }
+            if (isset($parts['user'])) {
+                $options['username'] = $parts['user'];
+            }
+            if (isset($parts['pass'])) {
+                $options['password'] = $parts['pass'];
+            }
+            if (isset($parts['host'])) {
+                $options['host'] = $parts['host'];
+            }
+            if (isset($parts['port'])) {
+                $options['port'] = $parts['port'];
+            }
+            if (isset($parts['query'])) {
+                parse_str($parts['query'], $query);
+                foreach ($options as $key => $value) {
+                    if (isset($query[$key])) {
+                        $options[$key] = $query[$key];
+                    }
+                }
+            }
+        }
+
+        if (!isset($options['transport'])) {
+            $options['transport'] = 'null';
+        } elseif ('gmail' === $options['transport']) {
+            $options['encryption'] = 'ssl';
+            $options['auth_mode'] = 'login';
+            $options['host'] = 'smtp.gmail.com';
+            $options['transport'] = 'smtp';
+        }
+
+        if (!isset($options['port'])) {
+            $options['port'] = 'ssl' === $options['encryption'] ? 465 : 25;
+        }
+
+        return $options;
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/config/php/urls.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/urls.php
@@ -4,7 +4,7 @@ $container->loadFromExtension('swiftmailer', array(
     'default_mailer' => 'smtp_mailer',
     'mailers' => array(
         'smtp_mailer' => array(
-            'url' => 'smtp://username:password@example.com:12345?encryption=tls&auth_mode=login',
+            'url' => 'smtp://username:password@example.com:12345?transport=smtp&username=user&password=pass&host=example.org&port=23456&timeout=42&source_ip=127.0.0.1&local_domain=local.example.com&encryption=tls&auth_mode=login',
         ),
     ),
 ));

--- a/Tests/DependencyInjection/Fixtures/config/xml/urls.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/urls.xml
@@ -7,7 +7,7 @@
 
     <swiftmailer:config default-mailer="smtp_mailer">
         <swiftmailer:mailer name="smtp_mailer"
-            url="smtp://username:password@example.com:12345?encryption=tls&amp;auth_mode=login">
+            url="smtp://username:password@example.com:12345?transport=smtp&amp;username=user&amp;password=pass&amp;host=example.org&amp;port=23456&amp;timeout=42&amp;source_ip=127.0.0.1&amp;local_domain=local.example.com&amp;encryption=tls&amp;auth_mode=login">
         </swiftmailer:mailer>
     </swiftmailer:config>
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/env_variable.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/env_variable.yml
@@ -1,0 +1,2 @@
+swiftmailer:
+    url: '%env(SWIFTMAILER_URL)%'

--- a/Tests/DependencyInjection/Fixtures/config/yml/urls.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/urls.yml
@@ -2,4 +2,4 @@ swiftmailer:
     default_mailer: smtp_mailer
     mailers:
         smtp_mailer:
-            url: smtp://username:password@example.com:12345?encryption=tls&auth_mode=login
+            url: smtp://username:password@example.com:12345?transport=smtp&username=user&password=pass&host=example.org&port=23456&timeout=42&source_ip=127.0.0.1&local_domain=local.example.com&encryption=tls&auth_mode=login

--- a/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
+++ b/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SwiftmailerBundle\Tests\DependencyInjection;
+
+use Symfony\Bundle\SwiftmailerBundle\DependencyInjection\SwiftmailerTransportFactory;
+use Symfony\Component\Routing\RequestContext;
+
+class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateTransportWithSmtp()
+    {
+        $options = array(
+            'transport' => 'smtp',
+            'username' => 'user',
+            'password' => 'pass',
+            'host' => 'host',
+            'port' => 1234,
+            'timeout' => 42,
+            'source_ip' => 'source_ip',
+            'local_domain' => 'local_domain',
+            'encryption' => 'encryption',
+            'auth_mode' => 'auth_mode',
+        );
+
+        $transport = SwiftmailerTransportFactory::createTransport(
+            $options,
+            new RequestContext(),
+            new \Swift_Events_SimpleEventDispatcher()
+        );
+        $this->assertInstanceOf('Swift_Transport_EsmtpTransport', $transport);
+        $this->assertSame($transport->getHost(), $options['host']);
+        $this->assertSame($transport->getPort(), $options['port']);
+        $this->assertSame($transport->getEncryption(), $options['encryption']);
+        $this->assertSame($transport->getTimeout(), $options['timeout']);
+        $this->assertSame($transport->getSourceIp(), $options['source_ip']);
+
+        $authHandler = current($transport->getExtensionHandlers());
+        $this->assertSame($authHandler->getUsername(), $options['username']);
+        $this->assertSame($authHandler->getPassword(), $options['password']);
+        $this->assertSame($authHandler->getAuthMode(), $options['auth_mode']);
+    }
+
+    public function testCreateTransportWithSendmail()
+    {
+        $options = array(
+            'transport' => 'sendmail',
+        );
+
+        $transport = SwiftmailerTransportFactory::createTransport(
+            $options,
+            new RequestContext(),
+            new \Swift_Events_SimpleEventDispatcher()
+        );
+        $this->assertInstanceOf('Swift_Transport_SendmailTransport', $transport);
+    }
+
+    public function testCreateTransportWithNull()
+    {
+        $options = array(
+            'transport' => 'null',
+        );
+
+        $transport = SwiftmailerTransportFactory::createTransport(
+            $options,
+            new RequestContext(),
+            new \Swift_Events_SimpleEventDispatcher()
+        );
+        $this->assertInstanceOf('Swift_Transport_NullTransport', $transport);
+    }
+
+    /**
+     * @dataProvider optionsAndResultExpected
+     */
+    public function testResolveOptions($options, $expected)
+    {
+        $result = SwiftmailerTransportFactory::resolveOptions($options);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function optionsAndResultExpected()
+    {
+        return array(
+            array(
+                array(
+                    'url' => '',
+                ),
+                array(
+                    'transport' => 'null',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 25,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                    'url' => '',
+                ),
+            ),
+            array(
+                array(
+                    'url' => 'smtp://user:pass@host:1234',
+                ),
+                array(
+                    'transport' => 'smtp',
+                    'username' => 'user',
+                    'password' => 'pass',
+                    'host' => 'host',
+                    'port' => 1234,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                    'url' => 'smtp://user:pass@host:1234',
+                ),
+            ),
+            array(
+                array(
+                    'url' => 'smtp://user:pass@host:1234?transport=sendmail&username=username&password=password&host=example.com&port=5678',
+                ),
+                array(
+                    'transport' => 'sendmail',
+                    'username' => 'username',
+                    'password' => 'password',
+                    'host' => 'example.com',
+                    'port' => 5678,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                    'url' => 'smtp://user:pass@host:1234?transport=sendmail&username=username&password=password&host=example.com&port=5678',
+                ),
+            ),
+            array(
+                array(
+                    'url' => 'smtp://user:pass@host:1234?timeout=42&source_ip=source_ip&local_domain=local_domain&encryption=encryption&auth_mode=auth_mode',
+                ),
+                array(
+                    'transport' => 'smtp',
+                    'username' => 'user',
+                    'password' => 'pass',
+                    'host' => 'host',
+                    'port' => 1234,
+                    'timeout' => 42,
+                    'source_ip' => 'source_ip',
+                    'local_domain' => 'local_domain',
+                    'encryption' => 'encryption',
+                    'auth_mode' => 'auth_mode',
+                    'url' => 'smtp://user:pass@host:1234?timeout=42&source_ip=source_ip&local_domain=local_domain&encryption=encryption&auth_mode=auth_mode',
+                ),
+            ),
+            array(
+                array(),
+                array(
+                    'transport' => 'null',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 25,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                ),
+            ),
+            array(
+                array(
+                    'transport' => 'smtp',
+                ),
+                array(
+                    'transport' => 'smtp',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 25,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                ),
+            ),
+            array(
+                array(
+                    'transport' => 'gmail',
+                ),
+                array(
+                    'transport' => 'smtp',
+                    'username' => null,
+                    'password' => null,
+                    'host' => 'smtp.gmail.com',
+                    'port' => 465,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => 'ssl',
+                    'auth_mode' => 'login',
+                ),
+            ),
+            array(
+                array(
+                    'transport' => 'sendmail',
+                ),
+                array(
+                    'transport' => 'sendmail',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 25,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                ),
+            ),
+            array(
+                array(
+                    'encryption' => 'ssl',
+                ),
+                array(
+                    'transport' => 'null',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 465,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => 'ssl',
+                    'auth_mode' => null,
+                ),
+            ),
+            array(
+                array(
+                    'port' => 42,
+                ),
+                array(
+                    'transport' => 'null',
+                    'username' => null,
+                    'password' => null,
+                    'host' => null,
+                    'port' => 42,
+                    'timeout' => null,
+                    'source_ip' => null,
+                    'local_domain' => null,
+                    'encryption' => null,
+                    'auth_mode' => null,
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Example:
```yml
# MAILER_URL=transport://user:pass@host:port/?encryption=...&auth_mode=...
swiftmailer:
    url: "%env(MAILER_URL)%"
```

To do:

- [x] add the doc symfony/symfony-docs/pull/7510
- [x] add tests
