### PR TITLE
Ci fix after composer requirements changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: php
 
-php:
-  - 7.0
-  - 7.1
-
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,14 @@ language: php
 
 php:
   - 7.0
-  - hhvm
+  - 7.1
 
-dist: trusty
 sudo: false
 
 cache:
   directories:
     - vendor
     - $HOME/.composer/cache/files
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
-    - php: 5.6
-      env: DEPENDENCIES=dev
 
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - hhvm
 
+dist: trusty
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.0
       env: SYMFONY_VERSION=2.8.*@dev
     - php: 7.0
       env: DEPENDENCIES=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ cache:
     - vendor
     - $HOME/.composer/cache/files
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.0
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 7.0
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 7.0
+      env: DEPENDENCIES=dev
+
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update "symfony/symfony:$SYMFONY_VERSION"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "swiftmailer/swiftmailer": "~6.0.1",
+        "swiftmailer/swiftmailer": "^6.0.1",
         "symfony/dependency-injection": "~2.7|~3.0",
         "symfony/http-kernel": "~2.7|~3.0",
         "symfony/config": "~2.7|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "swiftmailer/swiftmailer": "~6.0",
+        "swiftmailer/swiftmailer": "~6.0.1",
         "symfony/dependency-injection": "~2.7|~3.0",
         "symfony/http-kernel": "~2.7|~3.0",
         "symfony/config": "~2.7|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "swiftmailer/swiftmailer": "^6.0.1",
         "symfony/dependency-injection": "~2.7|~3.0",
         "symfony/http-kernel": "~2.7|~3.0",
-        "symfony/config": "~2.7|~3.0"
+        "symfony/config": "~2.8|~3.0"
     },
     "require-dev": {
         "symfony/console": "~2.7|~3.0",


### PR DESCRIPTION
The bundle is now depending on Swiftmailer package ~6.0, which depends on PHP >= 7.0.
This makes the bundle incompatible with PHP <7.0, so Travis cannot run builds with php versions under 7.0, neither under HHVM, which is [not yet totally compatible with PHP 7.0](https://github.com/facebook/hhvm/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22php7+incompatibility%22+) 