### PR TITLE
Remove usage of deprcated ConsoleExceptionEvent for 3.3+

### DIFF
--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -79,7 +79,7 @@ class EmailSenderListener implements EventSubscriberInterface
         );
 
         if (class_exists('Symfony\Component\Console\ConsoleEvents')) {
-            $listeners[ConsoleEvents::EXCEPTION] = 'onException';
+            $listeners[class_exists('Symfony\Component\Console\Event\ConsoleErrorEvent') ? ConsoleEvents::ERROR :  ConsoleEvents::EXCEPTION] = 'onException';
             $listeners[ConsoleEvents::TERMINATE] = 'onTerminate';
         }
 


### PR DESCRIPTION
Fixes a deprecation occurring on any console error in symfony/symfony.
Closes #175 