### PR TITLE
Sendmail command to be customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor/
 /composer.lock
-

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,6 +86,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('url')->defaultNull()->end()
                 ->scalarNode('transport')->defaultValue('smtp')->end()
+                ->scalarNode('command')->defaultValue('/usr/sbin/sendmail -bs')->end()
                 ->scalarNode('username')->defaultNull()->end()
                 ->scalarNode('password')->defaultNull()->end()
                 ->scalarNode('host')->defaultValue('localhost')->end()

--- a/DependencyInjection/SwiftmailerTransportFactory.php
+++ b/DependencyInjection/SwiftmailerTransportFactory.php
@@ -63,6 +63,8 @@ class SwiftmailerTransportFactory
                 $eventDispatcher
             );
 
+            $transport->setCommand($options['command']);
+
             $smtpTransportConfigurator = new SmtpTransportConfigurator(null, $requestContext);
             $smtpTransportConfigurator->configure($transport);
         } elseif ('null' === $options['transport']) {
@@ -92,6 +94,7 @@ class SwiftmailerTransportFactory
             'local_domain' => null,
             'encryption' => null,
             'auth_mode' => null,
+            'command' => null
         );
 
         if (isset($options['url'])) {

--- a/Resources/config/schema/swiftmailer-1.0.xsd
+++ b/Resources/config/schema/swiftmailer-1.0.xsd
@@ -52,6 +52,7 @@
       <xsd:attribute name="disable-delivery" type="xsd:boolean" />
       <xsd:attribute name="sender-address" type="xsd:boolean" />
       <xsd:attribute name="url" type="xsd:string" />
+      <xsd:attribute name="command" type="xsd:string" />
   </xsd:attributeGroup>
 
   <xsd:complexType name="mailer">

--- a/Tests/DependencyInjection/Fixtures/config/php/sendmail.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/sendmail.php
@@ -3,4 +3,5 @@
 $container->loadFromExtension('swiftmailer', array(
     'transport' => 'sendmail',
     'local_domain' => 'local.example.org',
+    'command' => '/usr/sbin/sendmail -bs'
 ));

--- a/Tests/DependencyInjection/Fixtures/config/xml/sendmail.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/sendmail.xml
@@ -9,5 +9,6 @@
     <swiftmailer:config
         transport="sendmail"
         local-domain="local.example.org"
+        command="/usr/sbin/sendmail -bs"
     />
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/sendmail.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/sendmail.yml
@@ -1,3 +1,4 @@
 swiftmailer:
     transport:  sendmail
     local_domain: local.example.org
+    command: /usr/sbin/sendmail -bs

--- a/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
+++ b/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
@@ -53,6 +53,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $options = array(
             'transport' => 'sendmail',
+            'command' => '/usr/sbin/sendmail -bs'
         );
 
         $transport = SwiftmailerTransportFactory::createTransport(
@@ -178,6 +179,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'null',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 25,
                     'timeout' => null,
@@ -196,6 +198,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'smtp',
                     'username' => 'user',
                     'password' => 'pass',
+                    'command' => null,
                     'host' => 'host',
                     'port' => 1234,
                     'timeout' => null,
@@ -214,6 +217,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'sendmail',
                     'username' => 'username',
                     'password' => 'password',
+                    'command' => null,
                     'host' => 'example.com',
                     'port' => 5678,
                     'timeout' => null,
@@ -232,6 +236,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'smtp',
                     'username' => 'user',
                     'password' => 'pass',
+                    'command' => null,
                     'host' => 'host',
                     'port' => 1234,
                     'timeout' => 42,
@@ -248,6 +253,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'null',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 25,
                     'timeout' => null,
@@ -265,6 +271,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'smtp',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 25,
                     'timeout' => null,
@@ -282,6 +289,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'smtp',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => 'smtp.gmail.com',
                     'port' => 465,
                     'timeout' => null,
@@ -299,6 +307,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'sendmail',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 25,
                     'timeout' => null,
@@ -316,6 +325,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'null',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 465,
                     'timeout' => null,
@@ -333,6 +343,7 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit_Framework_TestCase
                     'transport' => 'null',
                     'username' => null,
                     'password' => null,
+                    'command' => null,
                     'host' => null,
                     'port' => 42,
                     'timeout' => null,


### PR DESCRIPTION
Hello there!
To my surprise I recently found out that your sendmail transport's command is not customizable by a parameter. Without any deeper knowledge of your Code of Conduct or Contribution rules, I allowed myself to create a pull request where I patched in the customizability of the Sendmail transport command property, for which you just configure it. The command by default keeps on the known value, so this PR is backward-compatible.

It occured to me that the `sendmail-bundle` does work fine on default configurations of Linux servers but it would fail on Linux machines which are configured differently. That is, where `sendmail` does not happen to be part of `/usr/sbin`. 

On a PHP environment you'd find a default set value in the config, named `sendmail_path`. This path would be completely ignored if you'd lock out the ability for the user to configure the command freely. However I did not change the default value to that configuration field in order to keep sendmail and its Symfony Bundle in the known behavior. You (or the major project of Swiftmailer) probably want to consider including config's `sendmail_path` of PHP as default for Swiftmailer's sendmail transport command in your next major version.

I appreciate your feedback on this Pull Request, even if you don't merge it, so I can improve myself for more Pull Requests to come. Thank you very much and have a :sunny: day!

Herzmut