### PR TITLE
Added `command` to the list of parameters that can be set from enviro…

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -83,7 +83,7 @@ class SwiftmailerExtension extends Extension
 
         if (method_exists($container, 'resolveEnvPlaceholders')) {
             $options = array();
-            $envVariablesAllowed = array('transport', 'url', 'username', 'password', 'host', 'port', 'timeout', 'source_ip', 'local_domain', 'encryption', 'auth_mode');
+            $envVariablesAllowed = array('transport', 'url', 'username', 'password', 'host', 'port', 'timeout', 'source_ip', 'local_domain', 'encryption', 'auth_mode', 'command');
             foreach ($envVariablesAllowed as $key) {
                 $container->resolveEnvPlaceholders($mailer[$key], null, $usedEnvs);
                 $options[$key] = $mailer[$key];

--- a/Tests/DependencyInjection/Fixtures/config/php/sendmail_no_command.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/sendmail_no_command.php
@@ -1,0 +1,6 @@
+<?php
+
+$container->loadFromExtension('swiftmailer', array(
+    'transport' => 'sendmail',
+    'url' => '%env(SWIFTMAILER_URL)%',
+));

--- a/Tests/DependencyInjection/Fixtures/config/xml/sendmail_no_command.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/sendmail_no_command.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd">
+
+
+    <swiftmailer:config
+        transport="sendmail"
+        url="%env(SWIFTMAILER_URL)%"
+    />
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/sendmail_no_command.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/sendmail_no_command.yml
@@ -1,0 +1,3 @@
+swiftmailer:
+    transport: sendmail
+    url: "%env(SWIFTMAILER_URL)%"

--- a/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -97,6 +97,20 @@ class SwiftmailerExtensionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getConfigTypes
      */
+    public function testSendmailDynamicConfigWithoutCommand($type)
+    {
+        $container = $this->loadContainerFromFile('sendmail_no_command', $type, array(), true);
+        $container->getAlias('swiftmailer.transport')->setPublic(true);
+
+        /** @var \Swift_SendmailTransport $transport */
+        $transport = $container->get('swiftmailer.transport');
+
+        $this->assertEquals('/usr/sbin/sendmail -bs', $transport->getCommand());
+    }
+
+    /**
+     * @dataProvider getConfigTypes
+     */
     public function testNullTransport($type)
     {
         $container = $this->loadContainerFromFile('null', $type);


### PR DESCRIPTION
…nment variables and default config values.

Why this is necessary:

without it the `$options` array does not contain the `command` parameter that contains either set or default value and is effectively `null`.