### PR TITLE
Implement missing reset() method

### DIFF
--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -41,11 +41,8 @@ class MessageDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $this->data = array(
-            'mailer' => array(),
-            'messageCount' => 0,
-            'defaultMailer' => '',
-        );
+        $this->reset();
+
         // only collect when Swiftmailer has already been initialized
         if (class_exists('Swift_Mailer', false)) {
             $mailers = $this->container->getParameter('swiftmailer.mailers');
@@ -65,6 +62,18 @@ class MessageDataCollector extends DataCollector
                 }
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array(
+            'mailer' => array(),
+            'messageCount' => 0,
+            'defaultMailer' => '',
+        );
     }
 
     /**


### PR DESCRIPTION
With (upcoming) Symfony 4 the `Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface` has introduced the new `reset()` method to be implemented.