### PR TITLE
Revert SF 3.4 constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         "php": ">=7.0.0",
         "swiftmailer/swiftmailer": "^6.0.1",
         "symfony/dependency-injection": "~2.7|~3.3|~4.0",
-        "symfony/http-kernel": "~2.7|~3.0|~4.0",
-        "symfony/config": "~2.8|~3.0|~4.0"
+        "symfony/http-kernel": "~2.7|~3.3|~4.0",
+        "symfony/config": "~2.8|~3.3|~4.0"
     },
     "require-dev": {
         "symfony/console": "~2.7|~3.3|~4.0",
-        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.7|~3.3|~4.0",
         "symfony/phpunit-bridge": "~3.3|~4.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0"
+        "symfony/yaml": "~2.7|~3.3|~4.0"
     },
     "suggest": {
         "psr/log": "Allows logging"

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": ">=7.0.0",
         "swiftmailer/swiftmailer": "^6.0.1",
-        "symfony/dependency-injection": "~2.7|~3.4|~4.0",
+        "symfony/dependency-injection": "~2.7|~3.0|~4.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
-        "symfony/console": "~2.7|~3.4|~4.0",
+        "symfony/console": "~2.7|~3.0|~4.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/phpunit-bridge": "~3.3|~4.0",
         "symfony/yaml": "~2.7|~3.0|~4.0"

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": ">=7.0.0",
         "swiftmailer/swiftmailer": "^6.0.1",
-        "symfony/dependency-injection": "~2.7|~3.0|~4.0",
+        "symfony/dependency-injection": "~2.7|~3.3|~4.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
-        "symfony/console": "~2.7|~3.0|~4.0",
+        "symfony/console": "~2.7|~3.3|~4.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/phpunit-bridge": "~3.3|~4.0",
         "symfony/yaml": "~2.7|~3.0|~4.0"


### PR DESCRIPTION
See https://github.com/symfony/swiftmailer-bundle/issues/198

Just a quick PR to see what tests do, but i believe this was forgotten as we reverted special 3.4 features, exactly for BC.