### PR TITLE
Add missing NTLM Authenticator to swiftmailer.xml

### DIFF
--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -27,6 +27,7 @@
                 <argument type="service"><service class="Swift_Transport_Esmtp_Auth_CramMd5Authenticator" public="false" /></argument>
                 <argument type="service"><service class="Swift_Transport_Esmtp_Auth_LoginAuthenticator" public="false" /></argument>
                 <argument type="service"><service class="Swift_Transport_Esmtp_Auth_PlainAuthenticator" public="false" /></argument>
+                <argument type="service"><service class="Swift_Transport_Esmtp_Auth_NTLMAuthenticator" public="false" /></argument>
             </argument>
         </service>
 


### PR DESCRIPTION
Fixes https://github.com/symfony/swiftmailer-bundle/issues/207