### PR TITLE
#222: Added HTML previews to profiler

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -70,6 +70,53 @@
 {% endblock %}
 
 {% block panel %}
+    <style>
+        .message-preview {
+            width: 100%;
+            margin: 1em 0px;
+            border: 1px dashed #E0E0E0;
+        }
+        .message-preview:hover {
+            background-image: linear-gradient(45deg, #F3F3F3 25%, transparent 25%), linear-gradient(-45deg, #f5f5f5 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #F3F3F3 75%), linear-gradient(-45deg, transparent 75%, #F3F3F3 75%);
+            background-size: 20px 20px;
+            background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+        }
+        .message-preview-opener {
+            font-style: italic;
+        }
+    </style>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function(event) {
+            //Handling for (open in window) links
+            const openers = document.querySelectorAll('.message-preview-opener');
+            for (var o = 0; o < openers.length; ++o) {
+                openers[o].addEventListener('click', function (event) {
+                    const contentSource = document.getElementById(event.target.dataset.contentSource);
+                    const decodedContent = window.decodeURIComponent(contentSource.dataset.encodedSrc);
+                    window.open('about:blank').document.body.innerHTML = decodedContent;
+                });
+            }
+
+            //Handling for previews rednering
+            const previews = document.querySelectorAll('iframe[data-encoded-src]');
+            var decodedContent, innerDocument;
+            for (var i = 0; i < previews.length; ++i) {
+                previews[i].addEventListener('load', function (event) {
+                    //Resize iframe after full load
+                    event.target.height = event.target.contentWindow.document.body.scrollHeight;
+                });
+
+                decodedContent = window.decodeURIComponent(previews[i].dataset.encodedSrc);
+                innerDocument = previews[i].contentWindow.document;
+                innerDocument.open();
+                innerDocument.write(decodedContent);
+                innerDocument.close();
+                previews[i].height = innerDocument.body.scrollHeight; //Initialy resize
+            }
+        });
+    </script>
+
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
     {% if profiler_markup_version == 1 %}
@@ -138,6 +185,8 @@
             </div>
         {% else %}
             {% for message in collector.messages(name) %}
+                {% set messagePreviewPrefix = 'messaage-preview-' ~ loop.index %}
+
                 {% if loop.length > 1 %}
                     <h4>E-mail #{{ loop.index }} details</h4>
                 {% else %}
@@ -163,6 +212,20 @@
                         </pre>
                     </div>
 
+                    {%- if message.contentType != 'text/plain' %}
+                        <div class="card-block">
+                            <span class="label">Message body preview</span>
+                            <a href="#" class="message-preview-opener" data-content-source="{{ messagePreviewPrefix }}-body">(show in window)</a>
+
+                            <iframe
+                                    id="{{ messagePreviewPrefix }}-body"
+                                    class="message-preview"
+                                    sandbox="allow-same-origin"
+                                    data-encoded-src="{{ message.body|convert_encoding('UTF-8', message.charset)|url_encode }}"
+                            ></iframe>
+                        </div>
+                    {% endif %}
+
                     {% for messagePart in message.children if messagePart.contentType in ['text/plain', 'text/html'] %}
                         <div class="card-block">
                             <span class="label">Alternative part ({{ messagePart.contentType }})</span>
@@ -174,6 +237,20 @@
                                 {%- endif -%}
                             </pre>
                         </div>
+
+                        {%- if messagePart.contentType == 'text/html' %}
+                            <div class="card-block">
+                                <span class="label">Alternative part preview</span>
+                                <a href="#" class="message-preview-opener" data-content-source="{{ messagePreviewPrefix }}-part-{{ loop.index }}">(show in window)</a>
+
+                                <iframe
+                                        id="{{ messagePreviewPrefix }}-part-{{ loop.index }}"
+                                        class="message-preview"
+                                        sandbox="allow-same-origin"
+                                        data-encoded-src="{{ message.bodyPart|convert_encoding('UTF-8', messagePart.charset)|url_encode }}"
+                                ></iframe>
+                            </div>
+                        {% endif %}
                     {% endfor %}
 
                     {% set attachments = collector.extractAttachments(message) %}


### PR DESCRIPTION
After couple of attempts I made the previews, which I believe are easy to use and actually help.

## General look & feel
Fo the simplest e-mail the preview looks like that:
<img width="743" alt="simple-mail" src="https://user-images.githubusercontent.com/1227834/35480844-42c21c14-03dd-11e8-9391-95b4ba4dbf2b.png">

The preview also works properly with normal-sized e-mails:
![big-mail](https://user-images.githubusercontent.com/1227834/35480855-6d2cbf2c-03dd-11e8-95c5-c79d5d8ccd6e.png)
The preview supports main body & alternative parts. I tested it with HTML up to 6MB, which by itself is painful to scroll - no problems whatsoever.

## Bonuses
While developing the feature and getting feedback I extended the preview by two small additions:
  - Hovering over preview shows checkerboard pattern when e-mail body contains no explicit background defined:
  ![alt_checker](https://user-images.githubusercontent.com/1227834/35480900-4234f662-03de-11e8-8ab0-3423eca361a3.png)
  - Link to open preview in new window and actually test its responsiveness:
    <img height="30" alt="screenshot 2018-01-28 03 40 16" src="https://user-images.githubusercontent.com/1227834/35480911-a0ef01e8-03de-11e8-9b8b-97b220597d4d.png">
<img width="1242" alt="screenshot 2018-01-28 03 54 37" src="https://user-images.githubusercontent.com/1227834/35480930-166e11ca-03df-11e8-8a45-616e089f251c.png">




## Implementation notes
- Content is stored in an attribute, since using fake `<script type="text/x-preview">...</script>` failed if e-mail contained `</script>` for obvious reasons
 - Using `data:` protocol will be better (since requires no JS), but IE or Edge doesn't support text/html payloads
 - Data URI are limited to 2MB in Chrome. Attributes length doesn't seem to be a problem (tested with 6MB raw HTML)
 - Base64 encoding will be probably more elegant, but built-in `atob()` decoding function doesn't support UTF-8 (sic!) and `TextDecoder` is not supported in IE or Edge.
 - Solution was tested with 6MB payload in IE 11, Edge 14/15/16, FF 56 & 38, Chrome 63 & 43, Opera 48 & 29, Safari 11 & 7, Chrome Mobile 62 (Android), Safari Mobile 8.0. Every browser ~~survived~~ rendered the previews properly.
 - I'm a backend developer - if I did something stupid let me know ;-)

//Fixes #222