### PR TITLE
Improved the Symfony profiler panel

### DIFF
--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -54,10 +54,16 @@ class MessageDataCollector extends DataCollector
                 if ($this->container->has($loggerName)) {
                     $logger = $this->container->get($loggerName);
                     $this->data['mailer'][$name] = [
-                        'messages' => $logger->getMessages(),
+                        'messages' => [],
                         'messageCount' => $logger->countMessages(),
                         'isSpool' => $this->container->getParameter(sprintf('swiftmailer.mailer.%s.spool.enabled', $name)),
                     ];
+
+                    foreach ($logger->getMessages() as $message) {
+                        $message->__base64EncodedBody = base64_encode($message->getBody());
+                        $this->data['mailer'][$name]['messages'][] = $message;
+                    }
+
                     $this->data['messageCount'] += $logger->countMessages();
                 }
             }

--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -50,6 +50,43 @@
     {% endif %}
 {% endblock %}
 
+{% block head %}
+    {{ parent() }}
+    <style type="text/css">
+        /* utility classes */
+        .m-t-0 { margin-top: 0 !important; }
+        .m-t-10 { margin-top: 10px !important; }
+
+        /* basic grid */
+        .row {
+            display: flex;
+            flex-wrap: wrap;
+            margin-right: -15px;
+            margin-left: -15px;
+        }
+        .col {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+            position: relative;
+            width: 100%;
+            min-height: 1px;
+            padding-right: 15px;
+            padding-left: 15px;
+        }
+        .col-4 {
+            flex: 0 0 33.333333%;
+            max-width: 33.333333%;
+        }
+
+        /* small tabs */
+        .sf-tabs-sm .tab-navigation li {
+            font-size: 14px;
+            padding: .3em .5em;
+        }
+    </style>
+{% endblock %}
+
 {% block menu %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
@@ -146,27 +183,57 @@
 
                 <div class="card">
                     <div class="card-block">
-                        <span class="label">Message headers</span>
-                        <pre>{% for header in message.headers.all %}
-                            {{- header -}}
-                        {% endfor %}</pre>
+                        <span class="label">Subject</span>
+                        <h2 class="m-t-10">{{ message.headers.get('subject').value ?? '(empty)' }}</h2>
+                    </div>
+                    <div class="card-block">
+                        <div class="row">
+                            <div class="col col-4">
+                                <span class="label">From</span>
+                                <pre class="prewrap">{{ message.headers.get('from').toString|replace({'From:': ''}) }}</pre>
+
+                                <span class="label">To</span>
+                                <pre class="prewrap">{{ message.headers.get('to').toString|replace({'To:': ''}) }}</pre>
+                            </div>
+                            <div class="col">
+                                <span class="label">Headers</span>
+                                <pre class="prewrap">{% for header in message.headers.all if (header.fieldName ?? '') not in ['Subject', 'From', 'To'] %}
+                                    {{- header -}}
+                                {% endfor %}</pre>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="card-block">
-                        <span class="label">Message body</span>
-                        <pre>
-                            {%- if messagePart.charset is defined and message.charset %}
-                                {{- message.body|convert_encoding('UTF-8', message.charset) }}
-                            {%- else %}
-                                {{- message.body }}
-                            {%- endif -%}
-                        </pre>
+                        <div class="sf-tabs sf-tabs-sm">
+                            <div class="tab">
+                                <h3 class="tab-title">Raw content</h3>
+
+                                <div class="tab-content">
+                                    <pre class="prewrap" style="max-height: 600px">
+                                        {%- if messagePart.charset is defined and message.charset %}
+                                            {{- message.body|convert_encoding('UTF-8', message.charset) }}
+                                        {%- else %}
+                                            {{- message.body }}
+                                        {%- endif -%}
+                                    </pre>
+                                </div>
+                            </div>
+
+                            <div class="tab">
+                                <h3 class="tab-title">Rendered content</h3>
+
+                                <div class="tab-content">
+                                    <iframe class="full-width" style="min-height: 600px" src="data:text/html;base64,{{ message.__base64EncodedBody }}"></iframe>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     {% for messagePart in message.children if messagePart.contentType in ['text/plain', 'text/html'] %}
                         <div class="card-block">
                             <span class="label">Alternative part ({{ messagePart.contentType }})</span>
-                            <pre>
+                            <pre class="prewrap">
                                 {%- if messagePart.charset is defined and messagePart.charset %}
                                     {{- messagePart.body|convert_encoding('UTF-8', messagePart.charset) }}
                                 {%- else %}


### PR DESCRIPTION
This fixes #222 with an alternative and simpler approach to the one proposed in #223.

## Before

![before](https://user-images.githubusercontent.com/73419/36144064-2e0c947a-10ad-11e8-8005-81a0c294f634.png)

## After

The Subject, To and From are better displayed:

![after-1](https://user-images.githubusercontent.com/73419/36144074-31654f90-10ad-11e8-9a45-ecb5cedc89a8.png)

The email content is now displayed as raw HTML and rendered HTML (I used the Hacker News webpage as the content because I didn't have any complex HTML email):

![after-2](https://user-images.githubusercontent.com/73419/36144098-4e3c102c-10ad-11e8-8e6e-1dd08526dc8d.png)

