### PR TITLE
Fix compatibility with the inline_class_loader optimization of the DIC dumper

### DIFF
--- a/DependencyInjection/Compiler/EnsureNoHotPathPass.php
+++ b/DependencyInjection/Compiler/EnsureNoHotPathPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Bundle\SwiftmailerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Ensures that autoloading of Swiftmailer classes is not optimized by the hot path optimization.
+ *
+ * Swiftmailer has a special autoloader triggering the initialization of the library lazily.
+ * Bypassing the autoloader would thus break the library.
+ * This logic allows to keep applying the autoloading optimization on the container, forcing an
+ * opt-out only for the Swiftmailer classes, which is better than disabling the optimization
+ * entirely.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class EnsureNoHotPathPass extends AbstractRecursivePass
+{
+    protected function processValue($value, $isRoot = false)
+    {
+        if ($value instanceof Definition && 0 === strpos($value->getClass(), 'Swift_')) {
+            $value->clearTag('container.hot_path');
+        }
+
+        return parent::processValue($value, $isRoot);
+    }
+}

--- a/SwiftmailerBundle.php
+++ b/SwiftmailerBundle.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Bundle\SwiftmailerBundle;
 
+use Symfony\Bundle\SwiftmailerBundle\DependencyInjection\Compiler\EnsureNoHotPathPass;
 use Symfony\Component\Console\Application;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SwiftmailerBundle\DependencyInjection\Compiler\RegisterPluginsPass;
@@ -26,6 +28,12 @@ class SwiftmailerBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterPluginsPass());
+
+        // Older supported versions of Symfony don't have the parent class that EnsureNoHotPathPass extends from.
+        // But they don't have the hot_path optimization either, so not being able to register our pass is not an issue.
+        if (\class_exists('Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass')) {
+            $container->addCompilerPass(new EnsureNoHotPathPass(), PassConfig::TYPE_AFTER_REMOVING);
+        }
     }
 
     public function registerCommands(Application $application)


### PR DESCRIPTION
The special autoloading necessary to initialize Swiftmailer internals is incompatible with "inline_class_loader" optimization of the DIC dumper, as it bypasses the autoloading at runtime (doing it at compile-time instead).
Instead of forcing disabling the optimization when using SwiftmailerBundle, this adds a compiler pass ensuring that Swift classes are never marked as being hot path services (which are the one being optimized). This compiler pass runs after the Symfony pass determining the hot path, reverting the detection for impacted services.