### PR TITLE
Fix the handling of null as top-level extension config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->beforeNormalization()
+                ->ifNull()
+                ->thenEmptyArray()
+            ->end()
+            ->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return is_array($v) && !array_key_exists('mailers', $v) && !array_key_exists('mailer', $v);
                 })


### PR DESCRIPTION
Symfony 4 does not cast null to an empty array when loading the top-level YAML config anymore.
But the normalization creating a single default mailer in the prototyped node was not triggered when the top-level node was null. This now converts null to an empty array in the normalization logic.

This makes tests green again.