### PR TITLE
Do not set time/message limit on Configurable Spool if null

### DIFF
--- a/Command/SendEmailCommand.php
+++ b/Command/SendEmailCommand.php
@@ -95,8 +95,12 @@ EOF
         if ($transport instanceof \Swift_Transport_SpoolTransport) {
             $spool = $transport->getSpool();
             if ($spool instanceof \Swift_ConfigurableSpool) {
-                $spool->setMessageLimit($input->getOption('message-limit'));
-                $spool->setTimeLimit($input->getOption('time-limit'));
+                if (null !== $input->getOption('message-limit')) {
+                    $spool->setMessageLimit($input->getOption('message-limit'));
+                }
+                if (null !== $input->getOption('time-limit')) {
+                    $spool->setTimeLimit($input->getOption('time-limit'));
+                }
             }
 
             if ($spool instanceof \Swift_FileSpool) {

--- a/Tests/Command/SendEmailCommandTest.php
+++ b/Tests/Command/SendEmailCommandTest.php
@@ -29,6 +29,62 @@ class SendEmailCommandTest extends \PHPUnit\Framework\TestCase
         $this->assertStringEndsWith("5 emails sent\n", $tester->getDisplay());
     }
 
+    public function testTimeLimitInteger()
+    {
+        $realTransport = $this->getMockBuilder('Swift_Transport')->getMock();
+
+        $spool = $this->configurableSpool();
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $container = $this->buildContainer($spoolTransport, $realTransport);
+        $this->executeCommand($container, ['--time-limit' => 5]);
+
+        $this->assertSame(5, $spool->getTimeLimit());
+    }
+
+    public function testTimeLimitNull()
+    {
+        $realTransport = $this->getMockBuilder('Swift_Transport')->getMock();
+
+        $spool = $this->configurableSpool();
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $container = $this->buildContainer($spoolTransport, $realTransport);
+        $this->executeCommand($container);
+
+        $this->assertSame(null, $spool->getTimeLimit());
+    }
+
+    public function testMessageLimitInteger()
+    {
+        $realTransport = $this->getMockBuilder('Swift_Transport')->getMock();
+
+        $spool = $this->configurableSpool();
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $container = $this->buildContainer($spoolTransport, $realTransport);
+        $this->executeCommand($container, ['--message-limit' => 5]);
+
+        $this->assertSame(5, $spool->getMessageLimit());
+    }
+
+    public function testMessageLimitNull()
+    {
+        $realTransport = $this->getMockBuilder('Swift_Transport')->getMock();
+
+        $spool = $this->configurableSpool();
+
+        $spoolTransport = new \Swift_Transport_SpoolTransport(new \Swift_Events_SimpleEventDispatcher(), $spool);
+
+        $container = $this->buildContainer($spoolTransport, $realTransport);
+        $this->executeCommand($container);
+
+        $this->assertSame(null, $spool->getMessageLimit());
+    }
+
     public function testRecoverLoadbalancedTransportWithSpool()
     {
         $realTransport = $this->getMockBuilder('Swift_Transport')->getMock();
@@ -80,5 +136,19 @@ class SendEmailCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute($input, $options);
 
         return $tester;
+    }
+
+    /**
+     * @return \Swift_ConfigurableSpool
+     */
+    private function configurableSpool(): \Swift_ConfigurableSpool
+    {
+        return new class extends \Swift_ConfigurableSpool {
+            public function start() {}
+            public function stop() {}
+            public function isStarted() {}
+            public function queueMessage(\Swift_Mime_SimpleMessage $message) {}
+            public function flushQueue(\Swift_Transport $transport, &$failedRecipients = null) {}
+        };
     }
 }


### PR DESCRIPTION
Setting a `null` value for both time & message limit results in a casting to `integer` inside the `\Swift_ConfigurableSpool` class. This casts to 0 which either makes it process 0 or 1 messages (depending on when it's checked).