### PR TITLE
Reset wasExceptionThrown

### DIFF
--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -85,4 +85,9 @@ class EmailSenderListener implements EventSubscriberInterface
 
         return $listeners;
     }
+
+    public function reset()
+    {
+        $this->wasExceptionThrown = false;
+    }
 }

--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -55,6 +55,7 @@
 
         <service id="swiftmailer.email_sender.listener" class="Symfony\Bundle\SwiftmailerBundle\EventListener\EmailSenderListener">
             <tag name="kernel.event_subscriber" />
+            <tag name="kernel.reset" method="reset" />
             <argument type="service" id="service_container" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>


### PR DESCRIPTION
Fixes https://github.com/php-pm/php-pm-httpkernel/issues/62

The problem is that when an exception is thrown in a PPM worker, the variable wasExceptionThrown stays true in all subsequent requests therefore email sending stops.