### PR TITLE
[WIP] Auto-flush the memory spool after kernel.terminate

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -273,6 +273,7 @@ class SwiftmailerExtension extends Extension
                 ->setArguments([
                     new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name)),
                     new Reference(sprintf('swiftmailer.mailer.%s.spool', $name)),
+                    new Reference(sprintf('swiftmailer.mailer.%s.transport.real', $name)),
                 ])
             ;
 

--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -45,7 +45,9 @@
 
         <service id="swiftmailer.transport.smtp.abstract" class="Swift_Transport_EsmtpTransport" public="false" abstract="true" />
 
-        <service id="swiftmailer.transport.spool.abstract" class="Swift_Transport_SpoolTransport" public="false" abstract="true" />
+        <service id="swiftmailer.transport.spool.abstract" class="Symfony\Bundle\SwiftmailerBundle\Transport\FlushingSpoolTransport" public="false" abstract="true">
+            <tag name="kernel.reset" method="disableInstantFlush" />
+        </service>
 
         <service id="swiftmailer.spool.file.abstract" class="Swift_FileSpool" public="false" abstract="true">
             <argument>%kernel.root_dir%/../data/swiftmailer/spool</argument>

--- a/Transport/FlushingSpoolTransport.php
+++ b/Transport/FlushingSpoolTransport.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SwiftmailerBundle\Transport;
+
+use Swift_Events_EventDispatcher as EventDispatcher;
+use Swift_Mime_SimpleMessage;
+use Swift_Spool as Spool;
+use Swift_Transport as Transport;
+use Swift_Transport_SpoolTransport as SpoolTransport;
+
+class FlushingSpoolTransport extends SpoolTransport
+{
+    /**
+     * @var Transport
+     */
+    private $transport;
+
+    /**
+     * @var bool
+     */
+    private $instantFlush = false;
+
+    public function __construct(EventDispatcher $eventDispatcher, Spool $spool, Transport $transport)
+    {
+        $this->transport = $transport;
+
+        parent::__construct($eventDispatcher, $spool);
+    }
+
+    public function enableInstantFlush()
+    {
+        $this->instantFlush = true;
+        $this->flushSpool();
+    }
+
+    public function disableInstantFlush()
+    {
+        $this->instantFlush = false;
+    }
+
+    /**
+     * Sends messages all spooled messages.
+     *
+     * @return int The number of sent emails
+     */
+    public function flushSpool()
+    {
+        return $this->getSpool()->flushQueue($this->transport);
+    }
+
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    {
+        $sent = parent::send($message, $failedRecipients);
+
+        if ($this->instantFlush) {
+            $this->flushSpool();
+        }
+
+        return $sent;
+    }
+}


### PR DESCRIPTION
This PR adds a new spool transport that can be switched to automatically flush the spool on each message. This can be useful for mails that should be sent after the spool has been flushed on `kernel.terminate`.

Furthermore it would allow us to deprecate `Symfony\Bridge\Monolog\Handler\SwiftMailerHandler` and thus make it easier to implement Monolog 2 compatibility (symfony/symfony#27857).

#SymfonyConHackDay2018