### PR TITLE
Throwing Exception for bad URL formats

### DIFF
--- a/DependencyInjection/SwiftmailerTransportFactory.php
+++ b/DependencyInjection/SwiftmailerTransportFactory.php
@@ -99,7 +99,9 @@ class SwiftmailerTransportFactory
         ];
 
         if (isset($options['url'])) {
-            $parts = parse_url($options['url']);
+            if (false === ($parts = parse_url($options['url']))) {
+                throw new \InvalidArgumentException(sprintf('Supplied url [%s] is not a valid format.', $options['url']));
+            }
             if (isset($parts['scheme'])) {
                 $options['transport'] = $parts['scheme'];
             }

--- a/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
+++ b/Tests/DependencyInjection/SwiftmailerTransportFactoryTest.php
@@ -162,6 +162,33 @@ class SwiftmailerTransportFactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Supplied url [smtp://localhost:25&auth_mode=cra-md5] is not a valid format.
+     */
+    public function testCreateTransportWithBadURLFormat()
+    {
+        $options = [
+            'url' => 'smtp://localhost:25&auth_mode=cra-md5',
+            'transport' => 'smtp',
+            'username' => null,
+            'password' => null,
+            'host' => 'localhost',
+            'port' => null,
+            'timeout' => 30,
+            'source_ip' => null,
+            'local_domain' => null,
+            'encryption' => null,
+            'auth_mode' => null,
+        ];
+
+        SwiftmailerTransportFactory::createTransport(
+            $options,
+            null,
+            new \Swift_Events_SimpleEventDispatcher()
+        );
+    }
+
+    /**
      * @dataProvider optionsAndResultExpected
      */
     public function testResolveOptions($options, $expected)


### PR DESCRIPTION
Hello there,

**Description** : When supplying a wrong URL format in the `MAILER_URL` environment variable, Swiftmailer Transport component is initialized with bundle default configuration values. 
Therefore, when trying to send emails, a "silent" error is triggered with the following message : `Exception occurred while flushing email queue: Connection could not be established with host localhost [Address not available #99]`.

**Changes made** : This PR now throws an `InvalidArgumentException` if supplied URL is not parseable by PHP's `parse_url` method.