### PR TITLE
Twig 2.10 Deprecation Update to swiftmailer.html.twig

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -197,7 +197,7 @@
                             </div>
                             <div class="col">
                                 <span class="label">Headers</span>
-                                <pre class="prewrap">{% for header in message.headers.all if (header.fieldName ?? '') not in ['Subject', 'From', 'To'] %}
+                                <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.fieldName ?? '') not in ['Subject', 'From', 'To']) %}
                                     {{- header -}}
                                 {% endfor %}</pre>
                             </div>
@@ -230,7 +230,7 @@
                         </div>
                     </div>
 
-                    {% for messagePart in message.children if messagePart.contentType in ['text/plain', 'text/html'] %}
+                    {% for messagePart in message.children|filter(messagePart => messagePart.contentType in ['text/plain', 'text/html']) %}
                         <div class="card-block">
                             <span class="label">Alternative part ({{ messagePart.contentType }})</span>
                             <pre class="prewrap">


### PR DESCRIPTION
This change addresses the following Twig deprecation:

> Adding an if condition on a for tag is deprecated in Twig 2.10. Use a filter filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop). https://twig.symfony.com/doc/2.x/deprecated.html

This solution uses the "filter" filter to maintain the single-tag "for" previously in place over adding a separate "if" tag. This requires Twig 1.41 or higher. (https://twig.symfony.com/doc/2.x/filters/filter.html)

A solution that does not use "filter" can be found at https://github.com/symfony/swiftmailer-bundle/pull/284
