### PR TITLE
Twig 2.10 Deprecation Update to swiftmailer.html.twig, without filter

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -197,9 +197,13 @@
                             </div>
                             <div class="col">
                                 <span class="label">Headers</span>
-                                <pre class="prewrap">{% for header in message.headers.all if (header.fieldName ?? '') not in ['Subject', 'From', 'To'] %}
-                                    {{- header -}}
-                                {% endfor %}</pre>
+                                <pre class="prewrap">
+                                    {%- for header in message.headers.all %}
+                                        {%- if (header.fieldName ?? '') not in ['Subject', 'From', 'To'] %}
+                                            {{- header -}}
+                                        {% endif -%}
+                                    {% endfor -%}
+                                </pre>
                             </div>
                         </div>
                     </div>
@@ -230,17 +234,19 @@
                         </div>
                     </div>
 
-                    {% for messagePart in message.children if messagePart.contentType in ['text/plain', 'text/html'] %}
-                        <div class="card-block">
-                            <span class="label">Alternative part ({{ messagePart.contentType }})</span>
-                            <pre class="prewrap">
-                                {%- if messagePart.charset is defined and messagePart.charset %}
-                                    {{- messagePart.body|convert_encoding('UTF-8', messagePart.charset) }}
-                                {%- else %}
-                                    {{- messagePart.body }}
-                                {%- endif -%}
-                            </pre>
-                        </div>
+                    {% for messagePart in message.children %}
+                        {% if messagePart.contentType in ['text/plain', 'text/html'] %}
+                            <div class="card-block">
+                                <span class="label">Alternative part ({{ messagePart.contentType }})</span>
+                                <pre class="prewrap">
+                                    {%- if messagePart.charset is defined and messagePart.charset %}
+                                        {{- messagePart.body|convert_encoding('UTF-8', messagePart.charset) }}
+                                    {%- else %}
+                                        {{- messagePart.body }}
+                                    {%- endif -%}
+                                </pre>
+                            </div>
+                        {% endif %}
                     {% endfor %}
 
                     {% set attachments = collector.extractAttachments(message) %}


### PR DESCRIPTION
This change addresses the following Twig deprecation:

> Adding an if condition on a for tag is deprecated in Twig 2.10. Use a filter filter or an "if" condition inside the "for" body instead (if your condition depends on a variable updated inside the loop). https://twig.symfony.com/doc/2.x/deprecated.html

This solution uses a separate "if" block instead of a "filter". This is due to "filter" requiring Twig 1.41 or higher. (https://twig.symfony.com/doc/2.x/filters/filter.html)

A solution that does use "filter" can be found at #282