### PR TITLE
Fixed custom sendmail command was never considered

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -214,6 +214,7 @@ class SwiftmailerExtension extends Extension
                     new Reference(sprintf('swiftmailer.mailer.%s.transport.buffer', $name)),
                     new Reference(sprintf('swiftmailer.mailer.%s.transport.eventdispatcher', $name)),
                 ])
+                ->addMethodCall('setCommand', [$mailer['command']])
                 ->setConfigurator([new Reference(sprintf('swiftmailer.transport.configurator.%s', $name)), 'configure'])
             ;
 

--- a/Tests/DependencyInjection/Fixtures/config/php/sendmail.php
+++ b/Tests/DependencyInjection/Fixtures/config/php/sendmail.php
@@ -3,5 +3,5 @@
 $container->loadFromExtension('swiftmailer', [
     'transport' => 'sendmail',
     'local_domain' => 'local.example.org',
-    'command' => '/usr/sbin/sendmail -bs',
+    'command' => '/usr/sbin/sendmail -t -i',
 ]);

--- a/Tests/DependencyInjection/Fixtures/config/xml/sendmail.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/sendmail.xml
@@ -9,6 +9,6 @@
     <swiftmailer:config
         transport="sendmail"
         local-domain="local.example.org"
-        command="/usr/sbin/sendmail -bs"
+        command="/usr/sbin/sendmail -t -i"
     />
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/sendmail.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/sendmail.yml
@@ -1,4 +1,4 @@
 swiftmailer:
     transport:  sendmail
     local_domain: local.example.org
-    command: /usr/sbin/sendmail -bs
+    command: /usr/sbin/sendmail -t -i

--- a/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -92,6 +92,11 @@ class SwiftmailerExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('swiftmailer.mailer.default.transport.sendmail', (string) $container->getAlias('swiftmailer.mailer.default.transport'));
 
         $this->assertEquals('local.example.org', $container->get('swiftmailer.mailer.default.transport')->getLocalDomain());
+
+        /** @var \Swift_SendmailTransport $transport */
+        $transport = $container->get('swiftmailer.transport');
+
+        $this->assertEquals('/usr/sbin/sendmail -t -i', $transport->getCommand());
     }
 
     /**


### PR DESCRIPTION
I tried configuring a different sendmail command in my Symfony application and noticed that it shows correctly when running `bin/console debug:config swiftmailer` but it's just never considered due to a missing `setCommand()` call on the transport.