### PR TITLE
Resolves ignored stream_options treatment

### DIFF
--- a/DependencyInjection/SwiftmailerExtension.php
+++ b/DependencyInjection/SwiftmailerExtension.php
@@ -84,7 +84,7 @@ class SwiftmailerExtension extends Extension
 
         if (method_exists($container, 'resolveEnvPlaceholders')) {
             $options = [];
-            $envVariablesAllowed = ['transport', 'url', 'username', 'password', 'host', 'port', 'timeout', 'source_ip', 'local_domain', 'encryption', 'auth_mode', 'command'];
+            $envVariablesAllowed = ['transport', 'url', 'username', 'password', 'host', 'port', 'timeout', 'source_ip', 'local_domain', 'encryption', 'auth_mode', 'command','stream_options'];
             foreach ($envVariablesAllowed as $key) {
                 $container->resolveEnvPlaceholders($mailer[$key], null, $usedEnvs);
                 $options[$key] = $mailer[$key];
@@ -146,7 +146,7 @@ class SwiftmailerExtension extends Extension
 
     protected function configureMailerTransport($name, array $mailer, ContainerBuilder $container, $transport, $isDefaultMailer = false)
     {
-        foreach (['encryption', 'port', 'host', 'username', 'password', 'auth_mode', 'timeout', 'source_ip', 'local_domain'] as $key) {
+        foreach (['encryption', 'port', 'host', 'username', 'password', 'auth_mode', 'timeout', 'source_ip', 'local_domain','stream_options'] as $key) {
             $container->setParameter(sprintf('swiftmailer.mailer.%s.transport.smtp.%s', $name, $key), $mailer[$key]);
         }
 


### PR DESCRIPTION
[fix] Resolve ignore stream_options treatment

If you use stream_options to send an email, the setting is ignored if you use URL or if you put the configuration directly in swiftmailer.yaml

With these changes, the issues are solved.