### PR TITLE
Used Symfony Flex in favor of symfony/lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.1
-      env: SYMFONY_LTS=^3
+      env: SYMFONY_REQUIRE="3.*"
     - php: 7.2
     - php: 7.3
       env: DEPENDENCIES=dev
 
 before_install:
     - phpenv config-rm xdebug.ini
-    - if [ "$SYMFONY_LTS" != "" ]; then composer require --dev --no-update "symfony/lts:$SYMFONY_LTS"; fi
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
     - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "symfony/console": "~2.7|~3.3|~4.0",
         "symfony/framework-bundle": "~2.7|~3.3|~4.0",
-        "symfony/phpunit-bridge": "~3.3|~4.0",
+        "symfony/phpunit-bridge": "^3.4.32|^4.3.5",
         "symfony/yaml": "~2.7|~3.3|~4.0"
     },
     "conflict": {


### PR DESCRIPTION
The `symfony/lts` package is deprecated. Global Symfony Flex + `SYMFONY_REQUIRE` is the new official way of limiting a Symfony version.