### PR TITLE
Remove not Symfony 5 compliant service argument %kernel.root_dir%

### DIFF
--- a/Resources/config/swiftmailer.xml
+++ b/Resources/config/swiftmailer.xml
@@ -48,7 +48,7 @@
         <service id="swiftmailer.transport.spool.abstract" class="Swift_Transport_SpoolTransport" public="false" abstract="true" />
 
         <service id="swiftmailer.spool.file.abstract" class="Swift_FileSpool" public="false" abstract="true">
-            <argument>%kernel.root_dir%/../data/swiftmailer/spool</argument>
+            <argument />
         </service>
 
         <service id="swiftmailer.spool.memory.abstract" class="Swift_MemorySpool" public="false" abstract="true" />


### PR DESCRIPTION
The service swiftmailer.spool.file.abstract uses %kernel.root_dir% in a path as its first argument. I think this argument is useless since it's replaced in `SwiftMailerExtension`. https://github.com/symfony/swiftmailer-bundle/blob/6b895bc0a5e815d1bf2d444869415a7c752516aa/DependencyInjection/SwiftmailerExtension.php#L262

Can anyone confirm it's not a BC break since a CompilerPass can't be registered and pass (and use this useless value) before `SwiftMailerExtension` code execution ?