### PR TITLE
Use sendmail_path as default value

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,7 +92,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('url')->defaultNull()->end()
                 ->scalarNode('transport')->defaultValue('smtp')->end()
-                ->scalarNode('command')->defaultValue('/usr/sbin/sendmail -bs')->end()
+                ->scalarNode('command')->defaultValue(@ini_get('sendmail_path') ?: '/usr/sbin/sendmail -bs')->end()
                 ->scalarNode('username')->defaultNull()->end()
                 ->scalarNode('password')->defaultNull()->end()
                 ->scalarNode('host')->defaultValue('localhost')->end()

--- a/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -110,7 +110,7 @@ class SwiftmailerExtensionTest extends \PHPUnit\Framework\TestCase
         /** @var \Swift_SendmailTransport $transport */
         $transport = $container->get('swiftmailer.transport');
 
-        $this->assertEquals('/usr/sbin/sendmail -bs', $transport->getCommand());
+        $this->assertEquals(@ini_get('sendmail_path') ?: '/usr/sbin/sendmail -bs', $transport->getCommand());
     }
 
     /**


### PR DESCRIPTION
Quite some time ago, Swiftmailer dropped support for the PHP `mail` function for security reasons and thus forcing you to use either `sendmail` or `smtp`. However, when using `sendmail`, The Swiftmailer Bundle only uses a hard coded command by default, which might not work on all hosting environments out of the box. The PHP `mail` function on the other hand uses the configured `sendmail_path` of the PHP configuration, which most likely will work in the respective hosting environment.

This PR simply uses the configured `sendmail_path` as the default value for the `command` parameter of the bundle configuration. Therefore emails should work again out of the box, just like it was before when Swiftmailer still supported PHP `mail`.

Kind of like the poor-man's version of https://github.com/symfony/symfony/pull/36131 ;)