### PR TITLE
Fix invalid encryption when using env

### DIFF
--- a/DependencyInjection/SwiftmailerTransportFactory.php
+++ b/DependencyInjection/SwiftmailerTransportFactory.php
@@ -144,7 +144,7 @@ class SwiftmailerTransportFactory
      */
     public static function validateConfig($options)
     {
-        if (!\in_array($options['encryption'], ['tls', 'ssl', null], true)) {
+        if (!\in_array($options['encryption'], ['tcp', 'tls', 'ssl', null], true)) {
             throw new \InvalidArgumentException(sprintf('The %s encryption is not supported', $options['encryption']));
         }
 


### PR DESCRIPTION
It is not possible to configure null as encryption using an environment variable. Allowing 'tcp' as configuration option would fix this issue. 'tcp' is the protocol set on the transporter wenn null is used.

Fix issue https://github.com/symfony/swiftmailer-bundle/issues/170