### PR TITLE
Fixing composer conflict section to allow twig/twig >=1.41,<2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/yaml": "^4.4|^5.0"
     },
     "conflict": {
-        "twig/twig": "<1.41|<2.10"
+        "twig/twig": "<1.41|>=2.0,<2.10"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SwiftmailerBundle\\": "" },


### PR DESCRIPTION
Constraint defined in composer.json conflict section prevents from using twig versions from 1.41 up to 2.0. Looking at the reason why this constraint was added 

- https://github.com/symfony/swiftmailer-bundle/pull/282
- https://github.com/symfony/swiftmailer-bundle/commit/2e5f0d61cf5d3b369c74b18dc0a72a158d95828d

it seems that this is an error and twig/twig >=1.41,<2.0 should be supported by this package since twig 1.41+ supports "filter" https://twig.symfony.com/doc/1.x/filters/filter.html