### PR TITLE
Fixing check for swiftmailer in EmailSenderListener

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+**Swiftmailer will stop being maintained at the end of November 2021.**
+
+Please, move to Symfony Mailer at your earliest convenience.
+Symfony Mailer is the next evolution of Swiftmailer.
+It provides the same features with support for modern PHP code and support for third-party providers.
+See https://symfony.com/doc/current/mailer.html for more information.
+
 # 3.5.0
 
  * Fix support for "stream_options" in configuration

--- a/DependencyInjection/Compiler/EnsureNoHotPathPass.php
+++ b/DependencyInjection/Compiler/EnsureNoHotPathPass.php
@@ -20,7 +20,7 @@ class EnsureNoHotPathPass extends AbstractRecursivePass
 {
     protected function processValue($value, $isRoot = false)
     {
-        if ($value instanceof Definition && 0 === strpos($value->getClass(), 'Swift_')) {
+        if ($value instanceof Definition && null !== ($class = $value->getClass()) && 0 === strpos($class, 'Swift_')) {
             $value->clearTag('container.hot_path');
         }
 

--- a/EventListener/EmailSenderListener.php
+++ b/EventListener/EmailSenderListener.php
@@ -45,7 +45,7 @@ class EmailSenderListener implements EventSubscriberInterface
 
     public function onTerminate()
     {
-        if (!$this->container->has('mailer') || $this->wasExceptionThrown) {
+        if ((!$this->container->has('mailer') && !$this->container->has('swiftmailer.mailer.default')) || $this->wasExceptionThrown) {
             return;
         }
         $mailers = array_keys($this->container->getParameter('swiftmailer.mailers'));

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,6 +1,12 @@
 Installation
 ============
 
+**Swiftmailer will stop being maintained at the end of November 2021.**
+
+Please, move to `Symfony Mailer <https://symfony.com/doc/current/mailer.html>`_ at your earliest convenience.
+`Symfony Mailer <https://symfony.com/doc/current/mailer.html>`_ is the next evolution of Swiftmailer.
+It provides the same features with support for modern PHP code and support for third-party providers.
+
 Step 1: Download the Bundle
 ---------------------------
 


### PR DESCRIPTION
When sending emails by injecting \Swift_Mailer and using the memory spool, no mails are sent out. There are no visible errors and mails are shown as correctly spooled in the profiler. However, the mails are never sent.

That is because the check for $container->has('mailer') in EmailSenderListener is always false at least with swiftmailer-bundle 3.5.2 on symfony 2.5.2. Additionally checking for 'swiftmailer.mailer.default' fixes the issue.