### PR TITLE
PHP 8.1: avoid deprecation message

### DIFF
--- a/DependencyInjection/Compiler/EnsureNoHotPathPass.php
+++ b/DependencyInjection/Compiler/EnsureNoHotPathPass.php
@@ -20,7 +20,7 @@ class EnsureNoHotPathPass extends AbstractRecursivePass
 {
     protected function processValue($value, $isRoot = false)
     {
-        if ($value instanceof Definition && 0 === strpos($value->getClass(), 'Swift_')) {
+        if ($value instanceof Definition && null !== ($class = $value->getClass()) && 0 === strpos($class, 'Swift_')) {
             $value->clearTag('container.hot_path');
         }
 


### PR DESCRIPTION
> strpos(): Passing null to parameter `#1` ($haystack) of type string is deprecated