### PR TITLE
Allow symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     "require": {
         "php": ">=7.1",
         "swiftmailer/swiftmailer": "^6.1.3",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/config": "^4.4|^5.0"
+        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+        "symfony/http-kernel": "^4.4|^5.0|^6.0",
+        "symfony/config": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
-        "symfony/console": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0",
-        "symfony/yaml": "^4.4|^5.0"
+        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0",
+        "symfony/yaml": "^4.4|^5.0|^6.0"
     },
     "conflict": {
         "twig/twig": "<1.41|>=2.0,<2.10"


### PR DESCRIPTION
I know the `swiftmailer/swiftmailer` package is abandoned in favor of `symfony/mailer`, but allowing symfony 6 makes it easier to add symfony 6 support to the [Kunstmaan CMS](https://github.com/Kunstmaan/KunstmaanBundlesCMS) and meanwhile refactor/deprecate parts of our code to move to `symfony/mailer` in a next major release.